### PR TITLE
Add 'How Claude Code Is Built' article

### DIFF
--- a/articles/by-topic/ai-technology.md
+++ b/articles/by-topic/ai-technology.md
@@ -4,6 +4,13 @@ Exploring the intersection of artificial intelligence and human ingenuity
 
 ## Articles
 
+### [How Claude Code Is Built](https://newsletter.pragmaticengineer.com/p/how-claude-code-is-built)
+*The Pragmatic Engineer • September 2025*
+
+A fascinating deep-dive into the engineering behind Claude Code—Anthropic's AI coding assistant. This behind-the-scenes look reveals the architectural decisions, technical challenges, and innovative approaches that went into building a tool that can actually write and modify code. It's like getting a backstage pass to one of the most interesting engineering projects in AI right now.
+
+**The wow moment:** The intricate dance between safety, capability, and usability that shapes every architectural decision. It's not just about making an AI that can code—it's about making one that codes responsibly.
+
 ### [The Perils of Using AI to Replace Entry-Level Jobs](https://hbr.org/2025/09/the-perils-of-using-ai-to-replace-entry-level-jobs)
 *Harvard Business Review • September 2025*
 

--- a/articles/index.md
+++ b/articles/index.md
@@ -4,6 +4,13 @@ A cabinet of fascinating reads, organized by curiosity rather than convention!
 
 ## Latest Additions
 
+### [How Claude Code Is Built](https://newsletter.pragmaticengineer.com/p/how-claude-code-is-built)
+*The Pragmatic Engineer • September 2025 • Read: September 2025*
+
+An engineering deep-dive into the architecture and design decisions behind Claude Code. This peek behind the curtain shows how Anthropic tackled the challenge of building an AI that can actually understand, write, and modify code safely and effectively. It's a masterclass in balancing capability with responsibility in AI development.
+
+**Engineering gold:** The thoughtful approach to tool use, context management, and safety boundaries that makes Claude Code both powerful and trustworthy.
+
 ### [Dev Culture Is Dying: The Curious Developer Is Gone](https://dayvster.com/blog/dev-culture-is-dying-the-curious-developer-is-gone/)
 *Dayvi Schuster • September 2025 • Read: September 2025*
 

--- a/articles/reading-log/2025-09.md
+++ b/articles/reading-log/2025-09.md
@@ -2,6 +2,17 @@
 
 *The curiosities that caught my attention this month*
 
+## Week 4
+
+### [How Claude Code Is Built](https://newsletter.pragmaticengineer.com/p/how-claude-code-is-built)
+*The Pragmatic Engineer • Read: September 25, 2025*
+
+This is meta on so many levels—reading about how Claude Code works while using Claude Code to add the article to my curiosity cabinet! 🎭 The Pragmatic Engineer delivers an incredible behind-the-scenes look at how Anthropic built their coding assistant. It's not just about the AI; it's about the entire system architecture, the safety considerations, and the clever engineering decisions that make it all work.
+
+What struck me most was the balance they've achieved between making Claude Code powerful enough to be genuinely useful (not just a fancy autocomplete) while keeping it safe and predictable. The tool use system, the context management, the careful boundaries—it's like watching a high-wire act where every safety net has been thoughtfully placed.
+
+**The revelation:** Building an AI coding assistant isn't just about training a model on code. It's about creating an entire ecosystem where AI and human developers can collaborate effectively. The real innovation isn't the AI itself—it's the interface between AI capabilities and human workflows.
+
 ## Week 3
 
 ### [Dev Culture Is Dying: The Curious Developer Is Gone](https://dayvster.com/blog/dev-culture-is-dying-the-curious-developer-is-gone/)


### PR DESCRIPTION
Closes #14

Added article from The Pragmatic Engineer about the architecture and engineering behind Claude Code to the curiosity cabinet collection.

Generated with [Claude Code](https://claude.ai/code)