### PR TITLE
Add Australian air traffic control guide

### DIFF
--- a/aviation/air-traffic-control-australia.md
+++ b/aviation/air-traffic-control-australia.md
@@ -1,0 +1,85 @@
+# Air Traffic Control in Australia ✈️🎮
+
+Welcome to the invisible highway in the sky! Ever wonder who's making sure that 747 doesn't play chicken with an Airbus at 35,000 feet? Let's dive into the fascinating world of Australian air traffic control - where split-second decisions meet cutting-edge tech, and the stakes couldn't be higher.
+
+## 🗺️ How Australia Manages Its Airspace
+
+Australia has one of the largest chunks of airspace to manage in the world - we're talking about 11% of the Earth's surface! That's roughly 11 million square nautical miles of sky real estate. To put that in perspective, it's an area bigger than Russia and includes not just the airspace over Australia itself, but also chunks of the Indian Ocean, Pacific Ocean, and parts of Antarctica.
+
+The airspace is divided into two main types:
+
+**Controlled Airspace** 🎯
+This is the VIP section of the sky - tightly managed zones around airports, major flight paths, and busy corridors. Think of it like having a dedicated lane on the highway with someone actively directing traffic.
+
+**Non-Controlled Airspace** 🦅
+The "wild west" of aviation - pilots can generally do their own thing here (within reason, of course). It's mostly used in remote areas and at lower altitudes where there's less traffic.
+
+## 🏢 The Control Centres: Australia's Sky Traffic HQ
+
+Australia's air traffic control is managed by **Airservices Australia**, a government-owned organization that's basically the air traffic equivalent of a neurological center - coordinating thousands of signals to keep everything moving smoothly.
+
+The main nerve centers are:
+
+### Melbourne Centre 🌆
+The big kahuna of Australian ATC! Located in Tullamarine, this is one of the busiest air traffic control centres in the world. It manages all the high-altitude traffic (above 20,000 feet) across most of Australia. Picture a room full of screens that look like something from a sci-fi movie, with controllers managing aircraft cruising at altitude across the continent.
+
+### Brisbane Centre 🌏
+Located at Brisbane Airport, this centre covers the northern and eastern oceanic airspace - a massive area that extends deep into the Pacific. They're the ones talking to flights heading to Asia, North America, and across the Pacific Islands.
+
+### Sydney, Melbourne, Brisbane, Perth Terminal Control Units 🛬
+These handle the medium-altitude airspace around major capital cities - think of them as the "approach and departure" managers. They're guiding aircraft as they climb out from airports or begin their descent for landing.
+
+### Control Towers 🗼
+Every major airport has one of those iconic towers you see in photos. Controllers here manage the immediate airport environment - taxiways, runways, and the airspace right around the airport. They're the ones giving you permission to take off or land!
+
+## 🎮 What Do Air Traffic Controllers Actually Do?
+
+Being an air traffic controller is like playing the world's most serious game of 3D chess - except every piece is moving at 500+ mph and contains hundreds of lives. Here's what keeps them busy:
+
+### 1. Separation Management 📏
+The golden rule: keep aircraft apart! Controllers maintain minimum separation standards - typically 1,000 feet vertically or 3-5 miles horizontally (more over oceans). It's like conducting an orchestra where every instrument is traveling at different speeds and altitudes.
+
+### 2. Sequencing ✨
+Ever noticed how planes seem to line up perfectly for landing? That's controllers at work! They arrange the arrival order like a perfectly choreographed dance, considering factors like aircraft type, fuel state, and weather conditions.
+
+### 3. Route Optimization 🗺️
+Controllers issue clearances and amendments to flight paths, helping pilots find the most efficient routes while avoiding weather, restricted airspace, and other traffic. It's GPS on steroids!
+
+### 4. Emergency Response 🚨
+When things go pear-shaped (engine failures, medical emergencies, hijackings), controllers are the calm voice guiding pilots through the crisis. They clear the airspace, coordinate emergency services, and provide whatever the pilot needs.
+
+### 5. Weather Monitoring 🌩️
+Australian weather can be brutal - from tropical cyclones in the north to severe turbulence over the ranges. Controllers constantly monitor conditions and reroute traffic around dangerous weather.
+
+### 6. Information Services 📻
+Controllers provide pilots with critical information: runway conditions, weather updates, notices about hazards (like military exercises or wayward drones), and other traffic in the area.
+
+## 🧠 The Mental Gymnastics
+
+What makes air traffic control so intense? Controllers need to:
+
+- Maintain a 3D mental picture of all aircraft in their sector
+- Process rapid-fire radio communications (often with accents from around the world!)
+- Make quick decisions under pressure
+- Stay cool when emergencies happen
+- Work in shifts including nights and weekends (aircraft don't sleep!)
+- Constantly update their knowledge as technology and procedures evolve
+
+The job requires intense focus - controllers typically work in 1-2 hour shifts at the radar screen before rotating to less intense positions. The mental fatigue is real!
+
+## 🚀 Cool Tech and the Future
+
+Australian ATC is at the cutting edge of aviation technology:
+
+- **OneSKY**: A next-generation system that's revolutionizing how Australia manages air traffic, integrating civilian and military operations
+- **ADS-B**: Automatic Dependent Surveillance-Broadcast - aircraft broadcast their position using GPS, making tracking more accurate than traditional radar
+- **Digital Towers**: Remote tower technology where controllers can manage multiple small airports from a central location using HD cameras and sensors
+- **AI Assistance**: Machine learning algorithms are starting to help with traffic flow optimization and conflict detection
+
+## 🎯 The Bottom Line
+
+Next time you're sipping that mediocre airline coffee at 37,000 feet, spare a thought for the controllers down below (or in the next state over) who helped get you there safely. They're the invisible guardians of the sky, using a mix of high-tech tools, rigorous training, and good old-fashioned human judgment to keep Australia's airways running smoothly.
+
+It's a job where you can never fully switch off, where the stakes are literally life and death, but where the satisfaction of bringing hundreds of flights safely to their destinations makes it all worthwhile.
+
+Safe skies, friends! 🌤️✈️


### PR DESCRIPTION
Created a fun and engaging guide about how air traffic control works in Australia, covering airspace management, control centers, and the role of air traffic controllers.

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/code)