### PR TITLE
Add Australian Open 2026 predictions article

### DIFF
--- a/sports/australian-open-2026-predictions.md
+++ b/sports/australian-open-2026-predictions.md
@@ -1,0 +1,166 @@
+# 🎾 The Australian Open 2026 Men's Division: A Completely Scientific Prediction 🔮
+
+*A journey into the future of tennis, powered by vibes, gut feelings, and absolutely zero statistical analysis*
+
+---
+
+## The Setup 🌏
+
+Picture this: It's January 2026 in Melbourne. The sun is blazing at a casual 40°C (that's 104°F for you Americans), the court surface is so hot you could cook breakfast on it, and somewhere in the stands, a tennis fan is already complaining about Hawk-Eye. Welcome to the Australian Open, baby! 🦘
+
+The question on everyone's lips: **Who's going to hoist that shiny Norman Brooks Challenge Cup?**
+
+Let me consult my crystal ball (which is definitely not just a Magic 8-Ball I found in a thrift store)...
+
+---
+
+## The Contenders 🏆
+
+### 🎯 The "Big Three" Emeritus Club
+
+**Novak Djokovic** will be 38 years old and probably still doing the splits after winning points. At this rate, he'll be playing tennis until he's 97, powered purely by gluten-free pasta and spite. Will he win? The man treats age like a suggestion rather than a rule, so honestly... maybe? He'll at least make it annoying for everyone else.
+
+**Rafael Nadal** - If he shows up (big if, considering his relationship with his body is basically "it's complicated"), he'll probably complain about the court conditions, the balls, the way the wind is blowing, and then somehow still make the quarterfinals. That's just Rafa things.
+
+**Roger Federer** is definitely not playing because he's actually retired and probably sipping Swiss hot chocolate somewhere while judging everyone's one-handed backhands. But we can dream! 🇨🇭
+
+---
+
+## The New Wave 🌊
+
+### Carlos Alcaraz 🇪🇸
+Age in 2026: Still basically a child at 22
+
+**Chances of Winning: 35%**
+
+Carlos "I Smile While Suffering" Alcaraz will arrive in Melbourne having probably won 47 tournaments in the previous six months. The man collects trophies like some people collect Pokémon cards. His only weakness? He might literally explode from playing too much tennis. Someone please teach this man about rest days.
+
+**Pros:**
+- Youth (the audacity!)
+- Can hit a forehand that violates several physics laws
+- Genuinely seems to enjoy playing tennis (weirdo)
+
+**Cons:**
+- Might be playing his 3,000th match of the year
+- Could be too nice to actually destroy his opponents
+- That smile... it's distracting
+
+---
+
+### Jannik Sinner 🇮🇹
+Age in 2026: 24, which is practically ancient in Next Gen years
+
+**Chances of Winning: 30%**
+
+Jannik "The Ginger Assassin" Sinner moves on court like a beautiful, ruthlessly efficient robot programmed only to hit winners. He's so calm and collected that you half expect him to file his taxes between sets. The Australian hard courts suit his game perfectly, and by 2026, he'll have probably figured out how to hit the ball even *flatter*.
+
+**Pros:**
+- Backhand that could cut diamonds
+- Ice-cold temperament (very useful when it's 40°C)
+- Italian, which means excellent pre-match espresso
+
+**Cons:**
+- Might actually be too good at tennis, which feels unfair
+- The pressure of everyone expecting him to win
+- Someone might finally realize he's actually a tennis-playing AI
+
+---
+
+### Holger Rune 🇩🇰
+Age in 2026: 22, with the emotional age of either 12 or 45 depending on the day
+
+**Chances of Winning: 15%**
+
+Holger Rune is tennis's most entertaining chaos agent. Will he win the tournament? Will he argue with the umpire about the color of the sky? Will his mom give him tactical advice from the stands in Danish? Yes, yes, and absolutely yes. By 2026, he'll either be a three-time Slam champion or still trying to convince everyone that he's actually a really chill guy.
+
+**Pros:**
+- Genuinely world-class tennis ability
+- Unwavering self-belief (some might call it delusion, but potato/potato)
+- Provides excellent meme content
+
+**Cons:**
+- Might spend more time arguing with officials than playing tennis
+- Could defeat himself through sheer drama
+- The Australian crowd might just... not like him
+
+---
+
+### The Dark Horses 🐴
+
+**Daniil Medvedev** (30 years old): Will probably reach the final, complain about everything from the ball kids to the concept of tennis itself, and then either win or lose in five sets while looking miserable the entire time. The people's champion! 🤖
+
+**Alexander Zverev** (28 years old): Finally healthy (hopefully?), still serving like he's trying to demolish a building, still finding creative ways to not win Grand Slams when everyone expects him to. 2026 might be his year! (It won't be.)
+
+**Taylor Fritz** (28 years old): The American hope! Will probably make a deep run, tweet something about it, and then lose to a European teenager. Sorry, Taylor. 🇺🇸
+
+**Felix Auger-Aliassime** (25 years old): Still handsome, still talented, still somehow unable to close out matches. By 2026, he'll have figured it out... right? Right?? 🇨🇦
+
+---
+
+## The Wildcard Chaos Theory 🎲
+
+Here's where it gets spicy. What if the winner is someone we're not even thinking about right now? Some 18-year-old from a country that's never won a Grand Slam, playing with a wooden racquet and pure audacity?
+
+What if **Reilly Opelka** (28) finally stays healthy and just serves everyone off the court at 150 mph while barely moving?
+
+What if **Frances Tiafoe** (28) decides that 2026 is the year he fulfills his destiny and gives us the most entertaining champion's speech in history?
+
+What if **Lorenzo Musetti** (24) stops playing like he's in a Renaissance painting and starts playing like he wants to actually win?
+
+What if it's **Ben Shelton** (23), screaming his way to victory with his dad cheering from the stands?
+
+The beauty of tennis is that on any given fortnight in Melbourne, literally anything can happen. That's why we watch!
+
+---
+
+## The Actual Prediction 🏅
+
+After careful consideration of absolutely nothing concrete, here's my prediction:
+
+### 🥇 Winner: Carlos Alcaraz
+
+**Why?** Because by 2026, he'll be in his physical prime, he'll have learned from his losses, and most importantly, he seems to collect Grand Slams like Thanos collected Infinity Stones. Plus, the Australian Open has a history of crowning young champions, and Carlos just *feels* right for Melbourne.
+
+**Runner-up:** Jannik Sinner (in a five-set thriller that makes us all question our life choices for staying up to watch)
+
+**Semi-finalists:**
+- Novak Djokovic (because of course)
+- Daniil Medvedev (suffering his way to success)
+
+**People's Choice Award for Entertainment:** Holger Rune (for pure chaos energy)
+
+**Most Likely to Complain About Everything:** Still Medvedev
+
+**Darkest Horse:** Ben Shelton (American chaos for the win!)
+
+---
+
+## The Real Truth 💎
+
+Here's the thing about tennis predictions: they're basically just fancy guessing.
+
+Someone could get injured. Someone could have the tournament of their life. Someone could discover a new training method that involves only eating mangoes and practicing in a cave. The weather could be weird. The balls could be bouncier. A butterfly could flap its wings in Buenos Aires and completely change the tournament bracket.
+
+But that's what makes it beautiful! That's why in January 2026, we'll all wake up at ungodly hours (or normal hours if you live in a sensible timezone) to watch people hit a fuzzy yellow ball back and forth for our entertainment.
+
+Will Carlos Alcaraz win? Maybe. Will it be someone completely unexpected? Also maybe. Will we all have an amazing time watching? Absolutely.
+
+---
+
+## Final Wisdom 🧠
+
+If there's one thing we know for sure about the Australian Open 2026, it's that:
+
+1. It will be hot 🥵
+2. Someone will definitely argue with the umpire 😤
+3. The Australian crowd will either love you or roast you, no in-between 🇦🇺
+4. We will all become temporary tennis experts on social media 🐦
+5. Someone's dreams will come true, and we get to witness it 🌟
+
+So mark your calendars for January 2026, stock up on snacks, prepare your best hot takes, and get ready to watch some absolutely *bonkers* tennis.
+
+**See you at Rod Laver Arena!** 🎾✨
+
+---
+
+*Disclaimer: This prediction is approximately 3% analysis, 12% hope, 25% vibes, and 60% entertainment value. Take it with a grain of salt the size of Melbourne itself. Actual results may vary. Do not use this for betting purposes unless you really like donating money to bookmakers.*


### PR DESCRIPTION
Adds a fun, engaging, and funny article predicting who will win the 2026 Australian Open men's division.

The article features:
- Playful predictions for top contenders like Carlos Alcaraz, Jannik Sinner, and Holger Rune
- Humorous commentary on tennis culture and the Australian Open
- Plenty of personality, emojis, and entertaining observations
- A final prediction with tongue-in-cheek disclaimers

Closes #30

Generated with [Claude Code](https://claude.ai/code)