### PR TITLE
Add Australian retail ownership research

### DIFF
--- a/companies/australian-retail-oligopoly.md
+++ b/companies/australian-retail-oligopoly.md
@@ -1,0 +1,161 @@
+# The Great Australian Retail Duopoly (and Friends) 🦘🛒
+
+*Or: How Two Companies Decided to Own Everything You Buy*
+
+## The Big Picture 🎯
+
+Australia's retail landscape is like a game of Monopoly where two players bought all the properties early and everyone else is just paying rent. Meet the heavyweight champions of separating Australians from their hard-earned dollarydoos!
+
+## 🥊 The Heavyweight Championship
+
+### Wesfarmers: The Octopus of Oz 🐙
+
+**Current Empire Includes:**
+- **Bunnings** 🔨 - Where every Australian dad finds inner peace on a Saturday morning
+- **Kmart** 👕 - Somehow became cool again? Fashion is weird
+- **Target** (Australia) 🎯 - Not the American one, confusingly
+- **Officeworks** 📎 - Where office supplies meet unexpected existential dread
+- **Priceline** 💄 - Your local pharmacy/beauty hybrid
+- **Catch.com.au** 📦 - Because they needed an online presence too
+
+**Fun Fact:** Wesfarmers started as a Western Australian farmers' cooperative in 1914. Now they're a $50+ billion conglomerate. Those were some ambitious farmers! 🌾➡️💰
+
+**The Vibe:** "We'll sell you literally everything from a hammer to mascara to a laminator, and you'll thank us for it."
+
+### Woolworths Group: Not Just Wool Anymore 🐑
+
+**Current Empire Includes:**
+- **Woolworths Supermarkets** 🥬 - "The fresh food people" (trademark lawyers worked overtime on that one)
+- **Big W** 🛍️ - The budget department store your mum loves
+- **Dan Murphy's** 🍷 - Australia's biggest booze baron
+- **BWS** (Beer Wine Spirits) 🍺 - For when Dan Murphy's is too far away
+- **Countdown** (New Zealand) 🥝 - They colonized the Kiwis too!
+
+**Fun Fact:** Despite the name, they haven't sold actual wool in decades. The company started in 1924 when a bunch of blokes decided selling groceries was easier than shearing sheep.
+
+**Market Share:** About 37% of Australian grocery sales. That's a LOT of Tim Tams.
+
+## 🥈 The Challengers
+
+### Coles Group: The Other Supermarket 🦅
+
+**Current Empire Includes:**
+- **Coles Supermarkets** 🛒 - Woolies' eternal frenemy
+- **Coles Express** ⛽ - Petrol and overpriced road trip snacks
+- **Liquorland** 🍾 - More booze! (Australians really like their alcohol retail)
+- **First Choice Liquor** 🥃 - Even MORE booze options!
+
+**Fun Fact:** Coles was part of Wesfarmers from 2007-2018, then got kicked out of the nest to fly solo again. Talk about a corporate divorce! 💔
+
+**Market Share:** About 28% of grocery sales. Forever the bridesmaid.
+
+**The Eternal Battle:** Coles vs Woolies is like Coke vs Pepsi, but with more aggressive price wars on bananas. 🍌
+
+### Aldi: The German Invasion 🇩🇪
+
+**What They Own:**
+- Aldi stores. That's it. They're focused like a laser.
+
+**Fun Fact:** Privately owned by the Albrecht family. They don't need your fancy stock market!
+
+**Market Share:** About 10% and climbing. Turns out Australians LOVE cheap groceries in a treasure-hunt format.
+
+**The Vibe:** "We have 4 brands of everything and you'll be confused but save money. Also here's a random kayak in aisle 3."
+
+## 🏪 The Specialists
+
+### Metcash: The Invisible Giant 👻
+
+You've probably never heard of them, but you've definitely shopped at their stores:
+- **IGA** (Independent Grocers of Australia) 🏪
+- **Foodland** (South Australia)
+- **Supa IGA**
+- **Cellarbrations** 🍷
+- **The Bottle-O** 🍺
+- **Mitre 10** 🔧 - Hardware stores (Bunnings' scrappy competitor)
+
+**Fun Fact:** They're a wholesaler/distributor that supplies independent stores. It's like being the puppet master of retail! 🎭
+
+### Harvey Norman: The Furniture & Electronics Maverick 📺
+
+**What They Do:**
+- Furniture, electronics, and the art of never having a sale that isn't "MASSIVE"
+- Franchise model: they own the buildings, franchisees run the stores
+- Somehow still relevant despite the internet existing
+
+**Fun Fact:** Founded by Gerry Harvey and Ian Norman in 1982. Gerry Harvey has... *opinions* about online retail. Strong ones. 🗣️
+
+## 🎪 The Plot Thickens: Who REALLY Owns What?
+
+Here's where it gets delicious:
+
+### The Property Angle 🏢
+- Woolworths and Coles don't just sell stuff - they own MASSIVE property portfolios
+- Shopping centers? Yeah, they probably own part of that too
+- It's vertical integration meets horizontal domination
+
+### The Private Label Game 🏷️
+Both major supermarkets have dozens of "home brands":
+- Woolworths: "Woolworths", "Macro", "Essentials"
+- Coles: "Coles", "Coles Finest", "Simply Less"
+- They're literally competing with their own suppliers. Spicy! 🌶️
+
+### The Pharmacy Wars 💊
+- Chemist Warehouse (privately owned by the Verrocchi and Gance families)
+- Priceline (Wesfarmers)
+- TerryWhite Chemmart (independent network)
+- Amcal (Sigma Healthcare)
+
+Even your paracetamol has corporate drama!
+
+## 📊 The Numbers That Make You Go "Hmmm" 🤔
+
+- **Woolworths + Coles = ~65% of Australian grocery market**
+- That's higher than similar duopolies in most developed countries
+- The ACCC (competition watchdog) watches them like a hawk watching mice
+- Every merger attempt gets VERY interesting
+
+## 🎭 The Drama & Controversies
+
+### The Milk Wars 🥛
+Remember when Coles dropped milk to $1/liter? Dairy farmers weren't thrilled. Woolies matched. Chaos ensued. This happened in 2011 and people STILL talk about it.
+
+### The Land Banking 📍
+Both majors have been accused of buying land just to prevent competitors from opening stores nearby. Chess, not checkers! ♟️
+
+### The Supplier Squeeze 🗜️
+Small suppliers report brutal negotiating tactics. When you control 65% of grocery retail, you have... let's say "leverage."
+
+## 🔮 The Future: Plot Twists Ahead?
+
+- **Amazon Australia** is trying to crash the party (with mixed success)
+- **Online grocery** is growing (thanks, pandemic!)
+- **Vertical farming** and **direct-to-consumer** models might shake things up
+- **ALDI's expansion** continues to chip away at the duopoly
+
+## 💭 The Philosophical Question
+
+Is it weird that two companies control where most Australians buy food, clothes, hardware, alcohol, and office supplies?
+
+The ACCC says: "We're watching." 👀
+
+Economists say: "Concerning market concentration."
+
+Your average Aussie says: "Yeah nah, but Bunnings snags though." 🌭
+
+## The Takeaway 🎁
+
+Australia's retail landscape is essentially:
+1. Wesfarmers (sells you everything for your house)
+2. Woolworths Group (sells you everything you eat and drink)
+3. Coles (like Woolworths but red instead of green)
+4. A bunch of scrappy underdogs trying to survive
+5. Aldi (the efficient German wildcard)
+
+It's capitalism, mate, but with a distinctly Australian oligopolistic flavor! 🦘
+
+---
+
+*Last updated: October 2025*
+*Research status: Based on publicly available information and corporate structures*
+*Accuracy: Pretty good, but companies shuffle brands like a card dealer on cruise control*


### PR DESCRIPTION
Adds a fun, playful deep-dive into the Australian retail landscape, covering the major players (Wesfarmers, Woolworths, Coles, Aldi) and their corporate empires.

Includes:
- Market share breakdown
- Corporate drama and controversies
- Fun facts and playful commentary
- The duopoly dynamics

Closes #48

Generated with [Claude Code](https://claude.ai/code)