### PR TITLE
Add meat paradox exploration

### DIFF
--- a/psychology/meat-paradox.md
+++ b/psychology/meat-paradox.md
@@ -1,0 +1,191 @@
+# The Meat Paradox: When Your Steak and Your Soul Don't Agree 🥩💭
+
+## The Uncomfortable Truth on Your Plate
+
+There's a special kind of mental gymnastics that happens every time someone pets a dog, coos over a cute pig video on Instagram, and then orders the rump steak at their local pub without batting an eye. Welcome to the meat paradox — where your love for animals and your love for eating animals engage in an eternal philosophical cage match.
+
+## What's the Beef? 🤔
+
+The meat paradox is a fascinating example of cognitive dissonance in action. It's the psychological discomfort that arises from holding two contradictory beliefs simultaneously:
+
+1. **Belief A**: Animals are sentient beings capable of suffering, and we shouldn't cause them unnecessary harm
+2. **Belief B**: This steak tastes amazing, and I'm definitely ordering another one
+
+Most meat-eaters genuinely care about animal welfare. They'd never kick a puppy, they donate to wildlife conservation, they're horrified by stories of animal cruelty. Yet... they also really, really enjoy bacon. And there's the rub.
+
+## The Psychology Behind the Paradox 🧠
+
+### Cognitive Dissonance: The Mind's Uncomfortable Roommate
+
+Leon Festinger's cognitive dissonance theory (1957) explains what happens when our actions clash with our beliefs. Our brains absolutely *hate* inconsistency — it's like nails on a psychological chalkboard. So when faced with conflicting ideas, we don't just sit there feeling uncomfortable. Oh no. We get creative.
+
+The dissonance creates mental tension that demands resolution. It's your brain saying, "One of these things is not like the other, and I'm going to lose my mind if we don't fix this RIGHT NOW."
+
+### The Mental Acrobatics: How We Cope 🤸
+
+To resolve this tension, we deploy various psychological strategies (aka "meat-eater's defense mechanisms"):
+
+#### 1. The "4 Ns" Justification
+Psychologists have identified four main justifications — the "4 Ns":
+
+- **Natural**: "Humans evolved to eat meat! We have canine teeth!"
+- **Normal**: "Everyone eats meat. It's what people do."
+- **Necessary**: "We need protein to survive!"
+- **Nice**: "But it tastes so good! Look at that marbling!"
+
+These justifications help reduce the psychological discomfort by making meat consumption seem rational, inevitable, and morally acceptable.
+
+#### 2. Categorization Magic: The "Pet vs. Food" Divide 🐕🐷
+
+We perform some impressive mental sorting:
+- **Dogs, cats, horses**: Friends! Family! Would never!
+- **Cows, pigs, chickens**: Umm... food category! Different thing entirely!
+
+This isn't universal, though. In some cultures, dogs are food and cows are sacred. The categories are cultural constructs, not universal truths — which makes the whole thing even more interesting (and uncomfortable if you think about it too hard).
+
+#### 3. Dissociation: Out of Sight, Out of Mind 🙈
+
+Modern food systems make this easy. Your steak doesn't look like a cow. It's packaged in plastic, labeled "beef," and served on a nice plate with béarnaise sauce. The disconnect between "animal" and "food" is carefully maintained by:
+
+- Euphemistic language ("pork" not "pig flesh")
+- Processing that removes recognizable features
+- Physical distance from slaughterhouses
+- Marketing that shows happy farms (narrator: the farms were not happy)
+
+#### 4. Avoiding Awareness: Strategic Ignorance 🚫
+
+Many meat-eaters practice what researchers call "strategic ignorance" — actively avoiding information about industrial farming. "Don't tell me, I don't want to know" becomes a protective mechanism. Ignorance isn't always bliss, but it sure reduces cognitive dissonance!
+
+## The Personal Paradox: Pub Steak vs. Principles 🍺🥩
+
+Let's get real for a moment. Imagine this scenario: You genuinely oppose animal cruelty. You support animal welfare legislation. You'd report animal abuse if you witnessed it. You share RSPCA posts. You're a *good person* who cares about animals.
+
+But Friday night rolls around, you're at the pub, and there it is on the menu: cheap rump steak, cooked medium-rare, maybe with some chips and peppercorn sauce. And you order it. Because it's delicious. Because it's Friday. Because... well, because you want to.
+
+### The Internal Dialogue 💬
+
+The conversation in your head might go something like this:
+
+**Conscience**: "You know that cow suffered, right?"
+
+**Hunger**: "Yes, but look, it's already dead. Me not eating it won't bring it back."
+
+**Conscience**: "That's not really how supply and demand works..."
+
+**Hunger**: "I'll eat less meat. Starting Monday."
+
+**Conscience**: "You said that last Friday."
+
+**Hunger**: "This is a *really good* deal on steak though."
+
+**Conscience**: "*Sigh*"
+
+### The Dissonance Dance 🕺
+
+This internal conflict *is* the meat paradox in microcosm. You're experiencing cognitive dissonance — that uncomfortable mental static that occurs when your actions (ordering steak) don't align with your values (opposing animal cruelty).
+
+Your brain has several options to resolve this:
+
+1. **Change the behavior**: Become vegetarian/vegan (reduces dissonance but requires significant lifestyle change)
+2. **Change the belief**: Decide you don't actually care about animal welfare (uncomfortable redefinition of self)
+3. **Add justifications**: "I only eat meat occasionally," "This is grass-fed," "Humans are omnivores," "It's already dead anyway"
+4. **Compartmentalize**: "Pets are different from food animals" (creates separate moral categories)
+5. **Minimize awareness**: Don't think about it too hard (ignorance as bliss)
+
+Most people choose option 3, 4, or 5 — it's the path of least resistance that allows them to keep both their steak *and* their self-image as an animal lover.
+
+## The Cultural Carnivore Context 🌍
+
+The meat paradox doesn't exist in a vacuum. We're embedded in cultures with deep meat-eating traditions:
+
+- **Social rituals**: BBQs, Sunday roasts, holiday turkeys
+- **Identity markers**: "Real men eat meat" (yes, people still say this)
+- **Economic systems**: Entire industries built on animal agriculture
+- **Culinary heritage**: Generations of family recipes and food memories
+
+Changing your relationship with meat isn't just about food — it's about identity, belonging, tradition, and culture. No wonder cognitive dissonance shows up to the party!
+
+## The Spectrum of Solutions 🌈
+
+People resolve (or don't resolve) the meat paradox in various ways:
+
+### The Avoiders 🙈
+Simply don't think about it. Strategic ignorance in full effect. "If I don't look at slaughterhouse footage, did it really happen?"
+
+### The Justifiers 📜
+Deploy the 4 Ns and other rationalizations. "This is natural/normal/necessary/nice!" Build elaborate philosophical frameworks to explain why their meat-eating is ethically fine, actually.
+
+### The Reducers 📉
+Eat less meat, buy "ethical" meat, practice "Meatless Mondays." A compromise position that reduces dissonance without requiring complete change.
+
+### The Switchers 🌱
+Go vegetarian or vegan. Align actions with values completely. Dissonance resolved! (Though they may develop new dissonances around social situations, nutrition, and identity).
+
+### The Acceptors 🤷
+Acknowledge the paradox and live with it. "Yes, it's ethically complicated. Yes, I still eat meat. I contain multitudes." Perhaps the most honest position, if the least comfortable.
+
+## The Research Rabbit Hole 🐰
+
+Studies on the meat paradox have found some fascinating patterns:
+
+- **Reminding people that meat comes from animals** reduces their willingness to eat it (temporarily)
+- **People rate animals as less intelligent and sentient** when they're about to eat them (motivated reasoning!)
+- **Meat-eaters avoid looking at pictures of animals** in contexts where they're about to eat meat
+- **The more someone likes meat**, the more they engage in moral disengagement strategies
+
+Our brains are *really good* at protecting us from uncomfortable truths, especially when those truths might require giving up something we enjoy.
+
+## The Philosophical Pickle 🥒
+
+The meat paradox raises some genuinely thorny philosophical questions:
+
+- If we acknowledge animal suffering but continue to eat meat, what does that say about our moral consistency?
+- Is it worse to cause suffering knowingly or unknowingly?
+- Can cognitive dissonance sometimes be... okay? Are we allowed to be complicated, contradictory beings?
+- Where do we draw the line between acceptable and unacceptable animal use?
+- Is there a coherent ethical framework that allows for meat-eating without cognitive dissonance?
+
+Philosophers, ethicists, and tipsy pub-goers have debated these questions for ages. The answers remain... well, let's just say there's no consensus.
+
+## The Compassionate Conclusion 💚
+
+Here's the thing: The meat paradox isn't about judging meat-eaters as hypocrites or vegans as preachy (though both stereotypes persist). It's about recognizing a genuinely difficult psychological and ethical situation that millions of people navigate daily.
+
+We're creatures of contradiction. We care about animals *and* we like how they taste. We value consistency *and* we engage in motivated reasoning. We want to be good people *and* we want that pub steak.
+
+The meat paradox is just one example of the countless contradictions we all live with. Maybe the first step isn't resolving it, but simply acknowledging it exists. Sitting with the discomfort. Asking ourselves honest questions:
+
+- Why do I eat meat?
+- What are my real values around animal welfare?
+- Am I making choices that align with those values?
+- If not, am I okay with that? Really?
+
+There's no "right" answer that works for everyone. But there's probably a more honest answer than "I've never really thought about it" — especially while ordering your third rump steak this week.
+
+## The Takeaway Platter 🍽️
+
+1. **The meat paradox is cognitive dissonance** between caring about animals and eating them
+2. **We use psychological strategies** to reduce the discomfort (justification, categorization, dissociation)
+3. **It's a deeply personal and cultural issue** — not just about individual choice
+4. **There's no single "solution"** — people resolve it differently (or don't)
+5. **Awareness is uncomfortable** but probably valuable
+6. **We contain multitudes** — being contradictory is part of being human
+
+## Final Thoughts from the Pub 🍺
+
+Next time you're at your local, staring at that cheap rump steak on the menu, you might feel a little twinge. That's your brain doing its cognitive dissonance thing. You can:
+
+- Order it anyway and enjoy it
+- Order something else
+- Order it and feel weird about it
+- Spiral into an existential crisis about the nature of moral consistency
+
+Any of these is valid! Well, maybe skip the existential crisis — the pub's supposed to be relaxing.
+
+The meat paradox isn't going away. It's baked into the modern human condition (medium-rare, with a side of ethical uncertainty). The question isn't whether you experience it — most meat-eaters do, even if they don't think about it. The question is: what do you do with that awareness?
+
+That's between you, your conscience, and your Friday night steak. 🥩
+
+---
+
+*Cognitive dissonance: It's what's for dinner.*


### PR DESCRIPTION
## Summary

Adds a new piece exploring the Meat Paradox — the cognitive dissonance between caring about animals and eating them.

## Changes
- Created `psychology/meat-paradox.md` with engaging, playful exploration of the topic
- Covers cognitive dissonance theory, psychological coping mechanisms, and personal reflection
- Includes the specific pub steak vs. animal welfare advocacy dilemma

Closes #66

———

Generated with [Claude Code](https://claude.ai/code)