### PR TITLE
Align article writing style guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,114 +1,56 @@
 # AGENTS.md
 
-## Mission
+## Project Type: Curiosity Cabinet 🎭
 
-Welcome to `curiosity-cabinet`, a notes-and-documentation repository for interesting ideas, useful references, research trails, biographies, website analyses, and the occasional intellectual detour that was definitely intentional.
+This is a Markdown-first notes and documentation project: a collection of thoughts, ideas, research trails, biographies, article notes, website analyses, and useful curiosities.
 
-This is not an application repo. There is no app to compile, no service to deploy, no secret microservice hiding in the ventilation ducts. It is a Markdown-first knowledge garden. Treat it like a museum drawer full of fascinating artifacts, not like a startup dashboard asking for a Q3 funnel chart.
+This is not an application repo. No app to compile. No service to deploy. No tiny server pretending it is "just here for the snacks."
 
-## Prime Directive
+## Key Rules
 
-Create and edit **Markdown files only**.
+### 📝 File Creation
 
-That means:
-
-- Use `.md` files for all new content.
+- Only create or edit Markdown (`.md`) files.
 - Do not add code files, config files, package files, generated assets, scripts, or build tooling.
-- Do not invent a software architecture for this repository.
-- Keep changes focused on writing, structure, links, and knowledge organization.
+- Keep changes focused on writing, structure, links, sources, and knowledge organization.
+- Preserve existing user-authored content unless the user explicitly asks for removal.
 
-If the task feels like it wants code, pause and reframe it as documentation unless the user explicitly changes the nature of the repository. This cabinet is for thoughts, not a tiny server wearing a trench coat.
+### 🎨 Writing Style
 
-## Writing Voice
+- Keep notes fun, playful, and curious. This is a curiosity cabinet, not a corporate manual wearing sensible shoes.
+- Use personality, whimsy, emojis, metaphors, and creative language where they help.
+- Be conversational rather than sterile or professionally beige.
+- Explain clearly first, then make the idea memorable with a good analogy, vivid image, or sharp little turn of phrase.
+- Use emojis as visual colour in titles, section headings, article lists, and callouts. They should help the page breathe and break up dense text.
+- Let the topic set the volume. A Brendan Eich profile can be bouncy and emoji-rich; a Cesare Beccaria profile can still be witty, but should respect the moral weight of crime, punishment, torture, and reform.
+- If the writing starts trying too hard to be funny, simplify. The joke should serve the idea, not leap in front of it wearing tap shoes.
 
-Write with the energy of Dr Ryland Grace explaining a weirdly beautiful fact while Ricky Stanicky keeps wandering in with a fake backstory, a suspiciously useful metaphor, and the absolute confidence of a rock musician explaining why the amp goes to eleven. Use them as broad character touchstones—resourceful, enthusiastic science communication on one side; magnificently overcommitted improvisation on the other—not as voices to copy line by line.
+Good target: "smart friend explaining the cool part, with enough humour and colour that the facts actually stick."
 
-Practical translation:
+Bad target: "technical documentation, academic fog, or a comedy routine stapled to a biography."
 
-- Be playful, witty, and memorable.
-- Stay insightful. The facts are the skeleton; humour is the nervous system, wardrobe, and inexplicable backstage rider demanding seventeen green grapes.
-- Prefer clear explanations over sterile summaries.
-- Use metaphors and references from science, music, sport, travel, movies, coding, and odd little everyday moments.
-- When explaining tricky ideas, reach first for analogies from music, sport, or TypeScript-style coding patterns if they fit. Good lanes include piano, guitar, drums, surfing, soccer, tennis, golf, and clear software concepts like types, interfaces, refactoring, and runtime surprises.
-- Make connections between ideas when they genuinely help.
-- Welcome tangents, but make them useful tangents. A segue should feel like a side quest with loot, not a wrong turn into a broom closet.
-- Keep the tone conversational, curious, and warm.
-- Avoid corporate filler, vague hype, and lifeless "knowledge base" prose.
-- Add dry rock-doc absurdity in the spirit of David St. Hubbins and Nigel Tufnel: oddly specific, charmingly overconfident, and just self-aware enough to land the joke.
-
-Good target: "museum guide who understands orbital mechanics, can explain black holes with a sandwich, and somehow knows a bassist who disappeared during a soundcheck."
-
-Bad target: "enterprise wiki page that has never seen sunlight."
-
-## Claude-Style Calibration
-
-Use the stronger existing article style as the house reference, especially the health and fitness series under `articles/by-topic/`. Do not use `companies/adobe.md` or `concepts/from-pikes-to-prison-reform.md` as tone anchors when matching the preferred article voice.
-
-The target is not merely "add jokes." The target is useful explanation with comic voltage running through the actual teaching:
-
-- Start with a concrete human moment: the awkward toe-touch, the long-run suffering, the "my back just made a bubble-wrap noise" problem. Let the reader feel the practical stakes before the theory arrives with a clipboard.
-- Explain the mechanism clearly, then attach a sticky analogy. Flexibility vs mobility becomes "long leash vs trained dog"; injury tracing becomes debugging upstream; endurance fatigue becomes a negotiation with the body's internal risk manager.
-- Put humour beside the facts, not after them. The joke should make the concept easier to remember, like a guitar riff that tells the drummer where the chorus is.
-- Prefer punchy reversals and memorable reframes: "the pain is in the back; the problem is in the hip", "easy should mean easy", "the message says stop, but it is a request, not a command."
-- Use occasional absurd specificity, but keep it visibly playful and lightweight. A suspiciously confident metaphor is welcome; invented factual claims are not.
-- Use emojis as visual colour and navigation, Claude-style. They work well in article titles, major section headings, reading-log headings, and important callouts because they break up dense text and give the page a quick visual rhythm. Use them intentionally, like stage lights, not like someone emptied a sticker drawer into the Markdown.
-- Keep the prose conversational and direct. Use short paragraphs, clean headings, bold labels, and lists where they help. The reader should feel guided, not buried under a textbook wearing a novelty hat.
-- Make the ending land with a practical takeaway or memorable principle, not a limp summary. Good notes leave the reader with a usable mental model and at least one phrase that follows them around like a catchy bassline.
-
-## Humour Directive
-
-Humour is a core part of the writing, not decorative seasoning sprinkled on after the facts have finished their annual compliance training.
-
-Aim for frequent, memorable humour throughout each note. The information must remain accurate and understandable, but the route may involve absurd metaphors, running jokes, fake anecdotes, dramatic overstatement, suspiciously specific details, and occasional sentences that appear to have escaped from another document wearing a false moustache.
-
-Prefer humour that:
-
-- appears naturally throughout the explanation, not only in introductions and conclusions;
-- uses callbacks and recurring comic ideas;
-- makes technical details easier to remember;
-- surprises the reader with an unexpected comparison;
-- includes dry asides, strange footnotes, and unnecessary confidence;
-- occasionally directs a playful, affectionate insult at the reader;
-- occasionally breaks the rhythm with a harmless non sequitur;
-- sounds like a brilliant friend explaining something after being banned from three regional museums.
-
-Use movie references freely when they fit—or when their unexpected arrival makes the explanation more memorable. Familiar touchstones include Dr Ryland Grace in *Project Hail Mary*, *Ricky Stanicky*, *Billy Madison*, *Happy Gilmore*, *Airplane!*, and whatever else the cinematic filing cabinet provides, from famous classics to obscure films the reader may enjoy discovering. Give enough context that someone who has not seen the movie still gets the point; a reference should open a small door, not demand a password and proof of Blockbuster membership.
-
-Throw in an occasional affectionate roast or playful banter-insult aimed at the reader. It should feel like teasing between friends and be so obviously ridiculous that it invites a laugh: "you magnificent walnut," "steady on, Professor Trousers," or "even you can follow this bit, you suspiciously confident turnip." Keep it warm, sparse, and absurd. Never target identity, appearance, intelligence, disability, trauma, insecurity, or any genuine vulnerability. The reader should feel included in the joke, not used as the dartboard.
-
-A sentence does not always need to advance the argument. Sometimes it may exist purely to check whether the reader is still paying attention. The submarine knows what it did.
-
-Do not limit humour to introductions and conclusions. Put it beside the detailed information, inside examples, between serious observations, and wherever the prose begins wearing beige trousers.
-
-Accuracy still matters. Never invent factual claims for a joke unless they are unmistakably presented as fictional or absurd. Fake anecdotes should be visibly fake; real people and events do not need surprise dialogue written for them like a director's cut nobody authorised.
-
-## Content Philosophy
-
-This repo is a curiosity cabinet: a place for collecting the sharp, strange, beautiful, hilarious, and useful things that make a person stop and say, "Wait, how does that work?"
-
-When adding or improving content:
+### 💭 Content Approach
 
 - Embrace curiosity and wonder.
-- Explain why the topic is interesting, not only what it is.
-- Include memorable details, quirks, contradictions, and human context.
-- Draw links to related topics where useful.
-- Capture rabbit holes worth exploring later.
-- Format for scanning: headings, short sections, lists, quotes, and links where they help.
-- Prefer vivid clarity over academic fog.
+- Make connections between ideas when they are genuinely useful.
+- Include interesting tangents, quirks, contradictions, and rabbit holes.
+- Format notes in an engaging, readable way with headings, short sections, bullets, quotes, and links where useful.
+- Prefer vivid clarity over exhaustive-but-dull coverage.
+- Include brief personal reactions or "why this matters" moments when they sharpen the note.
 
-Think "commonplace book with a lab coat and a fake mustache."
+Think "museum of interesting thoughts" rather than "technical documentation."
 
-## Repository Organization
+## 📂 Content Organization
 
-### People
+### 👤 Biographies
 
 When asked to add a new biography, profile, or person:
 
 - Create the file in `people/`.
 - Name it with lowercase words separated by hyphens, such as `ada-lovelace.md`.
-- Include what makes the person fascinating, not just a timeline of events.
-- Add quirks, contradictions, signature ideas, notable work, and why they matter.
-- Where helpful, include "rabbit holes" or "things to look up next."
+- Include what makes the person fascinating, not just a timeline.
+- Add interesting facts, quirks, contradictions, signature ideas, notable work, and why they matter.
+- Where helpful, include rabbit holes or things to look up next.
 
 Suggested shape:
 
@@ -126,13 +68,13 @@ Suggested shape:
 ## Follow-Up Rabbit Holes
 ```
 
-### Websites
+### 🌐 Website Analyses
 
 When asked to analyse a website or add a website analysis:
 
 - Create the file in `websites/`.
 - Name it after the domain or site name, such as `wonjyou-studio.md`.
-- Include design observations, content strategy, interaction details, engineering guesses, performance clues, and what makes the site worth remembering.
+- Include design observations, unique features, content strategy, interaction details, engineering clues, and what makes the site notable.
 - Separate observation from inference. If something is a guess, say so.
 
 Suggested shape:
@@ -155,7 +97,7 @@ Suggested shape:
 ## Follow-Up Rabbit Holes
 ```
 
-### Articles
+### 📚 Article Collection
 
 When asked to save an article or add an article link:
 
@@ -163,56 +105,36 @@ When asked to save an article or add an article link:
 - Add it to a relevant file in `articles/by-topic/` when it fits an existing or useful theme.
 - Add it to the appropriate monthly log in `articles/reading-log/`, such as `2026-07.md`.
 - Create missing Markdown files or directories as needed.
+- Use the current local date unless the user gives a specific date.
 
 Article entries should use this format:
 
 ```markdown
 ### [Article Title](url)
-
-*Source - Date read*
+*Source • Date read*
 
 Quick note about why this caught attention, the key insight, or what it connects to.
 ```
 
-Use the current local date when logging reading dates unless the user gives a specific date.
+## 🔎 Research And Sources
 
-## Style Details
-
-Use Markdown like a good set list: structured enough that the drummer knows where the chorus lands, loose enough that the guitar solo still has oxygen.
-
-- Use headings to create a clean route through the note.
-- Keep paragraphs digestible.
-- Use bullets when they improve scanning.
-- Add links where the source or reference matters.
-- Use blockquotes sparingly for short, memorable excerpts.
-- Add small "why this matters" moments when they sharpen the note.
-- Include follow-up references when the topic naturally name-drops people, books, theories, tools, places, or movements.
-
-Emoji are encouraged when they add visual rhythm, scanning landmarks, or useful flavour. Prefer one well-chosen emoji in page titles, section headers, article lists, and compact callouts over random inline sprinkles. A curiosity cabinet needs labels on the jars; a few bright labels help, a glitter cannon does not.
-
-## Research And Sources
-
-When facts matter:
-
-- Prefer reliable sources.
-- Include source links for claims that are specific, current, disputed, or easy to misremember.
+- Prefer reliable sources when facts matter.
+- Include source links for specific, current, disputed, or easy-to-misremember claims.
 - If browsing or external research is used, cite the source in the note.
 - Be clear about uncertainty.
 - Do not overquote. Summarize in your own words unless a short quote is especially useful.
 
-The goal is not to sound omniscient. The goal is to leave a trail future-you can follow without needing a detective board and three meters of red string.
-
-## Git Workflow
+## 🌿 Git Workflow
 
 Before starting a change:
 
 - Check the current branch and worktree state.
-- If there is existing user work, do not overwrite, reset, or casually juggle it like a guitarist throwing picks into the crowd.
+- If there is existing user work, do not overwrite or revert it.
 - Start new work from `main` unless the user asks otherwise.
 - Make sure `main` is up to date with the remote before branching.
 - Never commit directly to `main`.
 - Never push directly to `origin/main`.
-- Always use a separate branch and open a PR for review.
+- Use a separate branch and open a PR for review.
 - Use squash merges for completed PRs.
 
 ```bash
@@ -221,27 +143,6 @@ git pull --ff-only
 git switch -c short-descriptive-branch-name
 ```
 
-Use a focused branch name that describes the change, such as `add-website-analysis` or `update-article-index`.
+## Remember
 
-## Editing Rules
-
-- Preserve the existing organization unless the user asks for a restructure.
-- Keep filenames lowercase and hyphenated.
-- Do not remove user-authored content unless explicitly asked.
-- Improve clarity, flow, and usefulness without sanding off the personality.
-- If a note starts to become large, use headings before inventing new files.
-- If multiple notes are clearly emerging, split them sensibly and link them together.
-
-## What Good Looks Like
-
-A good entry in this repo should:
-
-- Teach something.
-- Spark a useful follow-up question.
-- Be pleasant to read.
-- Make connections without becoming a conspiracy corkboard.
-- Feel like a smart friend saying, "Okay, this is the cool part."
-
-## Final Reminder
-
-This is a cabinet of curiosities, not a codebase. Keep it Markdown, keep it useful, keep it alive. If the idea has a pulse, a weird corner, or a surprising connection, pin it neatly to the page and give it a good caption.
+This is a space for collecting and organizing interesting ideas, not for writing code. Every file should spark curiosity or capture a fascinating thought.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ The target is not merely "add jokes." The target is useful explanation with comi
 - Put humour beside the facts, not after them. The joke should make the concept easier to remember, like a guitar riff that tells the drummer where the chorus is.
 - Prefer punchy reversals and memorable reframes: "the pain is in the back; the problem is in the hip", "easy should mean easy", "the message says stop, but it is a request, not a command."
 - Use occasional absurd specificity, but keep it visibly playful and lightweight. A suspiciously confident metaphor is welcome; invented factual claims are not.
+- Use emojis as visual colour and navigation, Claude-style. They work well in article titles, major section headings, reading-log headings, and important callouts because they break up dense text and give the page a quick visual rhythm. Use them intentionally, like stage lights, not like someone emptied a sticker drawer into the Markdown.
 - Keep the prose conversational and direct. Use short paragraphs, clean headings, bold labels, and lists where they help. The reader should feel guided, not buried under a textbook wearing a novelty hat.
 - Make the ending land with a practical takeaway or memorable principle, not a limp summary. Good notes leave the reader with a usable mental model and at least one phrase that follows them around like a catchy bassline.
 
@@ -187,7 +188,7 @@ Use Markdown like a good set list: structured enough that the drummer knows wher
 - Add small "why this matters" moments when they sharpen the note.
 - Include follow-up references when the topic naturally name-drops people, books, theories, tools, places, or movements.
 
-Emoji are allowed when they add warmth, but do not turn the page into confetti. A curiosity cabinet needs labels on the jars.
+Emoji are encouraged when they add visual rhythm, scanning landmarks, or useful flavour. Prefer one well-chosen emoji in page titles, section headers, article lists, and compact callouts over random inline sprinkles. A curiosity cabinet needs labels on the jars; a few bright labels help, a glitter cannon does not.
 
 ## Research And Sources
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ This is not an application repo. No app to compile. No service to deploy. No tin
 - Be conversational rather than sterile or professionally beige.
 - Explain clearly first, then make the idea memorable with a good analogy, vivid image, or sharp little turn of phrase.
 - Use emojis as visual colour in titles, section headings, article lists, and callouts. They should help the page breathe and break up dense text.
-- Let the topic set the volume. A Brendan Eich profile can be bouncy and emoji-rich; a Cesare Beccaria profile can still be witty, but should respect the moral weight of crime, punishment, torture, and reform.
+- Let the topic set the volume. Light or eccentric subjects can be bouncy and emoji-rich; serious subjects can still be witty, but the humour should respect the weight of the material.
 - If the writing starts trying too hard to be funny, simplify. The joke should serve the idea, not leap in front of it wearing tap shoes.
 
 Good target: "smart friend explaining the cool part, with enough humour and colour that the facts actually stick."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,6 @@ This is not an application repo. No app to compile. No service to deploy. No tin
 - Be conversational rather than sterile or professionally beige.
 - Explain clearly first, then make the idea memorable with a good analogy, vivid image, or sharp little turn of phrase.
 - Use emojis as visual colour in titles, section headings, article lists, and callouts. They should help the page breathe and break up dense text.
-- Let the topic set the volume. Light or eccentric subjects can be bouncy and emoji-rich; serious subjects can still be witty, but the humour should respect the weight of the material.
 - If the writing starts trying too hard to be funny, simplify. The joke should serve the idea, not leap in front of it wearing tap shoes.
 
 Good target: "smart friend explaining the cool part, with enough humour and colour that the facts actually stick."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,20 @@ Good target: "museum guide who understands orbital mechanics, can explain black 
 
 Bad target: "enterprise wiki page that has never seen sunlight."
 
+## Claude-Style Calibration
+
+Use the stronger existing article style as the house reference, especially the health and fitness series under `articles/by-topic/`. Do not use `companies/adobe.md` or `concepts/from-pikes-to-prison-reform.md` as tone anchors when matching the preferred article voice.
+
+The target is not merely "add jokes." The target is useful explanation with comic voltage running through the actual teaching:
+
+- Start with a concrete human moment: the awkward toe-touch, the long-run suffering, the "my back just made a bubble-wrap noise" problem. Let the reader feel the practical stakes before the theory arrives with a clipboard.
+- Explain the mechanism clearly, then attach a sticky analogy. Flexibility vs mobility becomes "long leash vs trained dog"; injury tracing becomes debugging upstream; endurance fatigue becomes a negotiation with the body's internal risk manager.
+- Put humour beside the facts, not after them. The joke should make the concept easier to remember, like a guitar riff that tells the drummer where the chorus is.
+- Prefer punchy reversals and memorable reframes: "the pain is in the back; the problem is in the hip", "easy should mean easy", "the message says stop, but it is a request, not a command."
+- Use occasional absurd specificity, but keep it visibly playful and lightweight. A suspiciously confident metaphor is welcome; invented factual claims are not.
+- Keep the prose conversational and direct. Use short paragraphs, clean headings, bold labels, and lists where they help. The reader should feel guided, not buried under a textbook wearing a novelty hat.
+- Make the ending land with a practical takeaway or memorable principle, not a limp summary. Good notes leave the reader with a usable mental model and at least one phrase that follows them around like a catchy bassline.
+
 ## Humour Directive
 
 Humour is a core part of the writing, not decorative seasoning sprinkled on after the facts have finished their annual compliance training.


### PR DESCRIPTION
## Summary
- add Claude-style calibration notes based on the existing article voice
- clarify that Adobe and head-pikes notes should not be used as tone anchors
- encourage deliberate emoji use as visual rhythm in titles, headings, lists, and callouts

## Testing
- not run; Markdown documentation guidance only