### PR TITLE
Refresh historical notes writing style

### DIFF
--- a/companies/adobe.md
+++ b/companies/adobe.md
@@ -1,10 +1,12 @@
-# Adobe
+# 🎨 Adobe
 
-*A story about two mathematicians, one creek, a laser printer, several borrowed geniuses, and the gradual discovery that a monthly invoice can be more powerful than a printing press.*
+*Two mathematicians, one creek, a laser printer, several borrowed geniuses, and the gradual discovery that a monthly invoice can be more powerful than a printing press.*
 
-## Why Adobe Matters
+## ✨ Why Adobe Matters
 
-Adobe did not begin by trying to own creativity. It began with a problem so unglamorous it should have arrived wearing beige trousers: **how do you make a computer and a printer agree on what a page looks like?**
+Adobe did not begin by trying to own creativity. It began with a beautifully unglamorous problem: **how do you make a computer and a printer agree on what a page looks like?**
+
+That sounds small until you realise it is basically the Treaty of Versailles for fonts, margins, curves, and every newsletter ever produced by someone named Sandra with access to clip art.
 
 Solving that problem helped ignite desktop publishing. From there, Adobe accumulated tools that changed photography, illustration, filmmaking, documents, web animation, advertising, and the economics of creative work. It became less a software company than a geological layer. Dig anywhere in modern media and eventually you hit an `.ai`, `.psd`, `.pdf`, or the fossilised remains of a Flash loading screen stuck at 97%.
 
@@ -21,7 +23,7 @@ The interesting part is that Adobe’s empire was not built by one lone genius g
 
 That is the Adobe story: invention, partnership, acquisition, reinvention, and the occasional business decision that made customers stare into the middle distance like a golfer whose ball has entered a lake with unusual confidence.
 
-## Before Adobe: Two Men At Xerox PARC
+## 🧪 Before Adobe: Two Men At Xerox PARC
 
 In the late 1970s, **John Warnock** and **Charles “Chuck” Geschke** worked at Xerox’s Palo Alto Research Center, better known as **PARC**. PARC was one of history’s great idea factories: graphical interfaces, Ethernet, laser printing, object-oriented computing, and enough squandered commercial opportunity to make a venture capitalist chew through a mahogany desk.
 
@@ -37,7 +39,7 @@ So the pair left.
 
 Sources: [Adobe’s founders](https://www.adobe.com/about-adobe/leaders/founders.html), [Computer History Museum oral history with John Warnock](https://archive.computerhistory.org/resources/access/text/2017/06/102738071-05-01-acc.pdf).
 
-## 1982: A Company Named After The Water Out Back
+## 🌊 1982: A Company Named After The Water Out Back
 
 Warnock and Geschke founded Adobe in **December 1982**. The name came from **Adobe Creek**, which ran behind Warnock’s home in Los Altos, California. Other technology firms reached for mythological beings, fruit, or acronyms assembled during a carbon-monoxide leak. Adobe looked out the back window and named itself after some water.
 
@@ -47,7 +49,7 @@ The founders first considered building a complete printing system. Instead, they
 
 They called it **PostScript**.
 
-## PostScript: Teaching Printers To Think In Shapes
+## 🖨️ PostScript: Teaching Printers To Think In Shapes
 
 PostScript described a page using mathematical instructions. Text, lines, curves, and images could be defined independently of a particular printer and reproduced at high quality. Instead of telling the printer, “put ink on these exact dots and good luck, champion,” the computer could describe the page’s geometry and let the output device render it at the appropriate resolution.
 
@@ -69,7 +71,7 @@ It was the publishing equivalent of the home recording revolution. The studio di
 
 Sources: [Adobe on forty years of innovation](https://blog.adobe.com/en/publish/2022/12/05/celebrating-special-milestone-10-things-you-might-not-know-about-adobes-40-years-innovation), [Computer History Museum on desktop publishing](https://www.computerhistory.org/revolution/the-web/20/381).
 
-## Paul Brainerd And The Missing Instrument
+## 🧰 Paul Brainerd And The Missing Instrument
 
 PostScript and the LaserWriter were impressive machinery, but users still needed an approachable way to assemble pages. That came from **Paul Brainerd**, a newspaper veteran who founded **Aldus Corporation** in 1984.
 
@@ -81,7 +83,7 @@ The merger also brought an awkward overlap: Aldus owned **FreeHand**, a direct c
 
 Sources: [Computer History Museum on the Adobe–Aldus merger](https://www.computerhistory.org/tdih/august/31/), [FTC on the Adobe–Aldus consent order](https://www.ftc.gov/news-events/news/press-releases/1995/12/adobe-systems-incorporated-has-petitioned-ftc-reopen-modify-october-1994-consent-order).
 
-## The Knoll Brothers Make Reality Optional
+## 🖼️ The Knoll Brothers Make Reality Optional
 
 Adobe’s most famous product began elsewhere.
 
@@ -93,7 +95,7 @@ Photoshop’s great conceptual trick was not merely that it could alter photogra
 
 Photoshop became central to photography, publishing, advertising, film, science, and web design. Its name became a verb, which is the branding equivalent of being elected pope, except people mostly invoke you when a celebrity’s elbows look suspicious.
 
-### Russell Brown: The Evangelist In The Lab Coat
+### 🧑‍🔬 Russell Brown: The Evangelist In The Lab Coat
 
 Technology does not spread through engineering alone. It needs translators, performers, and at least one person willing to conduct a product demonstration as if revealing an alien artefact.
 
@@ -101,7 +103,7 @@ Technology does not spread through engineering alone. It needs translators, perf
 
 Sources: [Adobe on Photoshop’s origin](https://blog.adobe.com/en/publish/2017/12/06/photoshop-changing-photo-changing-industry), [Computer History Museum’s Photoshop exhibit](https://www.computerhistory.org/makesoftware/exhibit/photoshop/).
 
-## Warnock’s Impossible Document
+## 📄 Warnock’s Impossible Document
 
 By the early 1990s, Adobe had helped documents move from screen to printer. Warnock now wanted them to move reliably between computers.
 
@@ -113,7 +115,7 @@ PDF may be Adobe’s most important creation because it became boring. Courts, r
 
 Source: [PDF Association on ISO 32000-1](https://pdfa.org/resource/iso-32000-1/).
 
-## Chuck Geschke And The Human Company
+## 🤝 Chuck Geschke And The Human Company
 
 Geschke’s influence went beyond engineering and management. He and Warnock said they wanted Adobe to be a company where they themselves would want to work, built around trust, respect, and technical ambition.
 
@@ -123,7 +125,7 @@ Geschke served as Adobe’s president and later co-chairman. Warnock served as C
 
 Source: [Adobe’s founders](https://www.adobe.com/about-adobe/leaders/founders.html).
 
-## Macromedia And The Noisy Internet
+## ⚡ Macromedia And The Noisy Internet
 
 Adobe dominated print and images, but another company was defining the expressive early web.
 
@@ -141,7 +143,7 @@ Flash did not simply fail. It carried animation, games, and video across the web
 
 Sources: [Adobe–Macromedia acquisition announcement](https://www.sec.gov/Archives/edgar/data/913949/000104746905010580/a2156088zex-99_1.htm), [Web Design Museum on FutureSplash Animator](https://www.webdesignmuseum.org/software/futuresplash-animator-in-1996), [Adobe Flash end-of-life notice](https://community.adobe.com/announcements-637/update-on-flash-player-eol-719213).
 
-## Shantanu Narayen Changes The Business
+## 💳 Shantanu Narayen Changes The Business
 
 **Shantanu Narayen** joined Adobe in 1998, became president and chief operating officer in 2005, and succeeded **Bruce Chizen** as CEO in 2007. By then Adobe possessed famous products but faced piracy, irregular upgrade cycles, a shifting web, and customers who could quite reasonably keep using an old Creative Suite box for years.
 
@@ -155,7 +157,7 @@ This was not merely a pricing change. Narayen refactored Adobe’s relationship 
 
 Adobe also expanded aggressively into enterprise marketing. Acquisitions including **Omniture**, **Day Software**, **Magento**, **Marketo**, and **Workfront** moved the company from helping people create content to helping organisations manage, distribute, personalise, measure, and monetise it.
 
-## The People Adobe Bought Along The Way
+## 🛒 The People Adobe Bought Along The Way
 
 Adobe’s history is partly a history of recognising good ideas after other people had already wrestled them into existence:
 
@@ -173,7 +175,7 @@ This is not evidence that Adobe cannot invent. PostScript and PDF settle that ar
 
 Sometimes that works beautifully. Sometimes a beloved product is absorbed, repositioned, or retired. Buying a brilliant band does not guarantee the reunion album will have any songs on it.
 
-## The Figma Deal That Wasn’t
+## 🧩 The Figma Deal That Wasn’t
 
 In 2022, Adobe agreed to buy **Figma** for approximately **$20 billion**. Figma, co-founded by **Dylan Field and Evan Wallace**, had made interface design collaborative, browser-native, and multiplayer. It represented a product philosophy very different from Adobe’s traditional specialist desktop applications.
 
@@ -183,7 +185,7 @@ The episode matters because it revealed Adobe’s strategic anxiety. Figma had n
 
 Sources: [Adobe and Figma termination announcement](https://news.adobe.com/news/news-details/2023/adobe-and-figma-mutually-agree-to-terminate-merger-agreement), [UK Competition and Markets Authority inquiry](https://www.gov.uk/cma-cases/adobe-slash-figma-merger-inquiry).
 
-## Adobe Today
+## 🔮 Adobe Today
 
 As of **July 2026**, Adobe is no longer primarily the PostScript company, although its original instinct remains visible: identify a messy boundary between human intent and technical output, then build the layer everyone must pass through.
 
@@ -203,7 +205,7 @@ Narayen announced in March 2026 that he would step down as CEO once a successor 
 
 Sources: [Adobe FY2025 Form 10-K](https://www.sec.gov/Archives/edgar/data/796343/000079634326000003/adbe-20251128.htm), [Adobe leadership transition](https://news.adobe.com/news/2026/03/leadership-update), [Adobe completes Semrush acquisition](https://news.adobe.com/news/2026/04/adobe-completes-semrush-acquisition), [Adobe announces Topaz Labs acquisition](https://news.adobe.com/news/2026/06/adobe-to-acquire-topaz-labs).
 
-## The Shape Of The Whole Story
+## 🧭 The Shape Of The Whole Story
 
 Adobe began with two researchers who believed a page could be described mathematically. That idea connected a Macintosh to a laser printer and helped move publishing onto the desktop. The company then widened its definition of a page until it included photographs, illustrations, films, websites, contracts, shopping journeys, advertising campaigns, and AI-generated flamingos wearing dinner jackets.
 
@@ -220,7 +222,7 @@ At its most frustrating, Adobe mistakes dependence for affection. Subscription l
 
 That tension is the present-day Adobe: a company born from the liberation of the printed page, now powerful enough to feel like part studio, part utility company, and part landlord. The founders taught printers to understand ideas. Their successors built a very profitable gate around the ideas, added excellent lighting, and are currently installing an AI fog machine.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - **John Warnock’s Camelot paper** and the path from PostScript to PDF.
 - **Charles Geschke’s leadership philosophy** and Adobe’s early culture.
@@ -233,7 +235,7 @@ That tension is the present-day Adobe: a company born from the liberation of the
 - **Shantanu Narayen’s subscription pivot** as one of software’s defining business transformations.
 - **Content Credentials** and whether provenance can survive contact with the actual internet.
 
-## Source Shelf
+## 📚 Source Shelf
 
 - [Adobe founders](https://www.adobe.com/about-adobe/leaders/founders.html)
 - [Adobe: forty years of innovation](https://blog.adobe.com/en/publish/2022/12/05/celebrating-special-milestone-10-things-you-might-not-know-about-adobes-40-years-innovation)

--- a/concepts/from-pikes-to-prison-reform.md
+++ b/concepts/from-pikes-to-prison-reform.md
@@ -1,6 +1,8 @@
-# From Pikes to Prison Reform
+# 🏛️ From Pikes to Prison Reform
 
-## The Disturbing Question
+*How punishment went from public horror-show to legal paperwork, institutional reform, and the eternal human problem of “are we being civilised, or just quieter?”*
+
+## 😬 The Disturbing Question
 
 How did societies travel from severed heads above city gates and bodies displayed as political punctuation to courts that at least *claim* to value due process, proportionality, rehabilitation, and human dignity?
 
@@ -10,7 +12,7 @@ The useful way into the problem is to treat civilisation like an alarming scienc
 
 This note follows that crooked road. It discusses torture and execution without dwelling on anatomical detail; the point is to understand the machinery, not give the machinery a drum solo.
 
-## What Spectacular Punishment Was For
+## 🎪 What Spectacular Punishment Was For
 
 Premodern punishment was often deliberately public. The audience was part of the sentence.
 
@@ -22,11 +24,11 @@ An execution, mutilation, or displayed body could serve several purposes at once
 - **Humiliation and exclusion:** deny the condemned an ordinary death, burial, or reputation.
 - **Political communication:** a head on a gate said, with admirable economy and dreadful typography, “the government won.”
 
-Londoners, for example, encountered traitors’ heads on spikes, bodies in cages, and body parts fixed to gates. These were not hidden administrative procedures. They were state notices with terrible UX.
+Londoners, for example, encountered traitors’ heads on spikes, bodies in cages, and body parts fixed to gates. These were not hidden administrative procedures. They were state notices with terrible UX: the push notification was a head, and unsubscribing was discouraged.
 
 The exact methods varied by place, period, offence, and social rank. “The past” was never one legal system wearing a muddy hat. Nor was everyone enthusiastic: spectators could sympathise with the condemned, mock officials, riot, or treat the event as a holiday with alarmingly poor catering.
 
-## A Case Study in Rule by Terror
+## 🩸 A Case Study in Rule by Terror
 
 [Vlad III of Wallachia](../people/vlad-iii-dracula.md) became inseparable from impalement because he used exemplary violence as political and military theatre. Accounts describe forests of stakes intended to punish enemies and terrify others into obedience.
 
@@ -36,23 +38,23 @@ Propaganda operates on the Ricky Stanicky principle: begin with a useful story, 
 
 That distinction matters. Accuracy is not an apology for cruelty. It is how we avoid replacing history with a horror franchise.
 
-## Why the Old System Began to Lose Its Grip
+## 🔧 Why the Old System Began to Lose Its Grip
 
 There was no single turning point. Several changes began harmonising like a band that had previously communicated only by throwing cymbals.
 
-### 1. The state became more bureaucratic
+### 🗂️ 1. The state became more bureaucratic
 
 As governments developed police, courts, records, prisons, and professional administrators, punishment could become routine rather than spectacular. A reliable institution could project power every day; it did not always need a corpse above the bridge.
 
 This was not automatically more humane. Hidden cells can conceal abuse more efficiently than public scaffolds. The violence often changed location and form rather than vanishing.
 
-### 2. torture became an epistemic embarrassment
+### 🧠 2. Torture became an epistemic embarrassment
 
 Judicial torture was used partly to obtain confessions within legal systems that gave confession special evidentiary weight. The obvious bug—pain can make a person say whatever stops the pain—eventually became harder to ignore.
 
 [Cesare Beccaria](../people/cesare-beccaria.md) expressed the problem with devastating simplicity in 1764: if guilt is already certain, torture is unnecessary; if guilt is uncertain, the state may be torturing an innocent person. Either branch throws an error, you magnificent walnut.
 
-### 3. punishment acquired a new job description
+### 📋 3. Punishment acquired a new job description
 
 Enlightenment reformers increasingly argued that punishment should prevent future harm rather than avenge past wrongdoing through maximum suffering.
 
@@ -60,7 +62,7 @@ Beccaria emphasised clear laws, prompt and proportionate penalties, and preventi
 
 This sounds recognisably modern, but it carried a new danger: if institutions claim to “reform” people, they may justify intrusive surveillance and control as being for everyone’s benefit. Bentham’s Panopticon is the mascot of that uncomfortable sequel.
 
-### 4. suffering behind walls became visible
+### 🚪 4. Suffering behind walls became visible
 
 When imprisonment replaced many bodily penalties, prisons became the punishment rather than merely the cupboard where accused people waited for trial.
 
@@ -68,7 +70,7 @@ When imprisonment replaced many bodily penalties, prisons became the punishment 
 
 Her work was humane and paternalistic at once. Reformers are rarely delivered in morally perfect packaging; history has never respected semantic versioning.
 
-### 5. dignity became a legal principle
+### ⚖️ 5. Dignity became a legal principle
 
 After the organised barbarity of the Second World War, the 1948 Universal Declaration of Human Rights stated that no one should face torture or cruel, inhuman, or degrading treatment or punishment.
 
@@ -76,7 +78,7 @@ That sentence did not abolish torture by magic. International law is not Gandalf
 
 Later abolitionists converted principle into national law. [Robert Badinter](../people/robert-badinter.md), a lawyer who had watched France send one of his clients to the guillotine, led the successful parliamentary case for abolition of the French death penalty in 1981.
 
-## The Shape of the Change
+## 🧭 The Shape of the Change
 
 | Earlier emphasis | Reforming emphasis | Important catch |
 | --- | --- | --- |
@@ -89,11 +91,11 @@ Later abolitionists converted principle into national law. [Robert Badinter](../
 
 The big shift was not from “cruel people” to “kind people.” It was from one set of institutions, incentives, beliefs, and public rituals to another. Moral imagination mattered, but it gained traction when reformers translated it into books, inspection regimes, court procedure, legislation, and treaties.
 
-## Are We Modern Yet?
+## 🪞 Are We Modern Yet?
 
 Modern states still execute people. Torture and ill-treatment still occur. Prisons can produce isolation, violence, illness, and degradation. Democracies may condemn ancient cruelty while outsourcing suffering to remote detention centres or hiding it beneath procedural language smooth enough to sell a luxury hatchback.
 
-So this history is neither a victory lap nor proof that nothing improved. Both conclusions are lazy.
+So this history is neither a victory lap nor proof that nothing improved. Both conclusions are lazy, and frankly both have shown up late to training without shin pads.
 
 The useful lesson is that cruelty becomes normal when institutions make it ordinary, audiences accept its justifications, and victims are pushed outside the circle of concern. Reform begins when somebody changes the framing:
 
@@ -101,7 +103,7 @@ The useful lesson is that cruelty becomes normal when institutions make it ordin
 
 That question did not finish history. It did, however, ruin the old show.
 
-## A Family-Conversation Timeline
+## 🗓️ A Family-Conversation Timeline
 
 - **15th century:** Vlad III uses terror, including impalement, in the violent frontier politics of Wallachia.
 - **16th–18th centuries:** European states continue public executions and post-mortem displays; criticism grows alongside them.
@@ -113,7 +115,7 @@ That question did not finish history. It did, however, ruin the old show.
 - **1981:** France abolishes the death penalty after Badinter leads the government’s case.
 - **Now:** the argument continues, because civilisation is a maintenance project, not a trophy.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - Michel Foucault’s *Discipline and Punish*: did punishment become gentler, or merely quieter and more pervasive?
 - John Howard and the birth of systematic prison inspection.
@@ -123,7 +125,7 @@ That question did not finish history. It did, however, ruin the old show.
 - Why certainty of punishment may deter more effectively than severity.
 - The history of wrongful convictions and the special horror of irreversible penalties.
 
-## Sources and Further Reading
+## 📚 Sources and Further Reading
 
 - [London Museum — London’s public executions](https://www.londonmuseum.org.uk/collections/london-stories/londons-public-executions/)
 - [London Museum — Mapping London’s execution landscape](https://www.londonmuseum.org.uk/collections/london-stories/mapping-londons-execution/)

--- a/people/cesare-beccaria.md
+++ b/people/cesare-beccaria.md
@@ -1,6 +1,8 @@
-# Cesare Beccaria
+# ⚖️ Cesare Beccaria
 
-## Why He Matters
+*The Enlightenment thinker who looked at torture and arbitrary punishment and said, with dangerous calm, “Have we tried not being ridiculous?”*
+
+## ✨ Why He Matters
 
 Cesare Beccaria (1738–1794) looked at an 18th-century criminal system full of torture, secret proceedings, arbitrary penalties, and executions and asked an offensively sensible question:
 
@@ -10,7 +12,9 @@ His short 1764 book, *On Crimes and Punishments*, became one of the foundational
 
 Beccaria’s gift was to approach inherited cruelty like a scientist confronting a machine everyone else insists is traditional. Label the inputs. State the claimed output. Test whether the mechanism works. Ask why the lever marked TORTURE is connected directly to the warning light marked UNRELIABLE EVIDENCE. Try not to let the magistrate lick the sample.
 
-## The Interesting Bits
+The magic trick: he made cruelty look not only immoral, but badly designed. That is a brutal combo. Like losing a tennis match because your opponent has better ethics *and* a better backhand.
+
+## 🥊 The Interesting Bits
 
 Beccaria was a Milanese aristocrat associated with a circle of Enlightenment reformers sometimes called the Academy of Fists. The name suggests either intellectual combat or a regional wrestling promotion. In practice, the group debated economics, law, and government.
 
@@ -18,27 +22,27 @@ His friends Pietro and Alessandro Verri helped stimulate and shape the project. 
 
 The book initially appeared anonymously. Criticising criminal justice could irritate governments and religious authorities, both groups being historically poor at receiving one-star reviews.
 
-## Signature Ideas
+## 💡 Signature Ideas
 
-### Punishment should prevent, not avenge
+### 🧯 Punishment should prevent, not avenge
 
 For Beccaria, the legitimate purpose of punishment was to stop future crime. A penalty beyond what was necessary for that purpose was tyranny.
 
-### Certainty matters more than theatrical severity
+### 🎯 Certainty matters more than theatrical severity
 
 People are influenced more by a penalty’s promptness and likelihood than by a remote possibility of spectacular horror. A dependable consequence beats a monstrous but inconsistently applied one.
 
 This idea still stalks modern debates about deterrence, wearing sensible shoes and asking to see the data.
 
-### Laws should be clear and public
+### 📜 Laws should be clear and public
 
 Citizens should be able to know the law and the consequences of breaking it. Judges should not improvise penalties according to mood, status, or whether Mercury appeared to be in retrograde over the courthouse.
 
-### Punishment should be proportionate
+### 📏 Punishment should be proportionate
 
 Different offences should receive penalties scaled to the harm they cause society. If every offence carries the ultimate penalty, law loses its distinctions and offenders gain no incentive to stop short of worse harm.
 
-### Torture is both cruel and irrational
+### 🔥 Torture is both cruel and irrational
 
 Beccaria’s attack on torture was a logic trap:
 
@@ -50,13 +54,13 @@ The method is therefore morally vicious and informationally defective—the lega
 
 The delightful intellectual manoeuvre is that Beccaria does not need to know what happened in the interrogation room. He checks both possible states—guilt established and guilt not established—and torture fails in either one. It is a two-line proof with several centuries of blood on the error log.
 
-### The death penalty lacks necessity
+### 🛑 The death penalty lacks necessity
 
 Beccaria made one of the earliest sustained modern cases against capital punishment. He argued that the state generally had no need to kill a citizen and that long-lasting loss of liberty could create a stronger deterrent impression than an execution.
 
 His alternative punishments could themselves be severe, including lifelong penal labour. He was a reformer emerging from his century, not a visitor from a fully furnished 21st-century human-rights office.
 
-## Impact
+## 🌍 Impact
 
 *On Crimes and Punishments* was translated rapidly and influenced reform discussions across Europe and the Atlantic world. Tuscany became the first modern European state to abolish the death penalty in 1786, commonly linked to the intellectual climate Beccaria helped create.
 
@@ -64,7 +68,7 @@ His deeper achievement was to change the burden of proof. The question was no lo
 
 [Jeremy Bentham](jeremy-bentham.md) would build a more systematic utilitarian philosophy around that move. [Robert Badinter](robert-badinter.md) would still be making its abolitionist case in France more than two centuries later. Ideas sometimes tour longer than the Rolling Stones, with fewer scarves but similar disputes over the early material.
 
-## Contradictions and Limits
+## 🧱 Contradictions and Limits
 
 - Beccaria opposed excessive punishment but accepted harsh incarceration and forced labour.
 - His model treated rational legislation as the cure while paying less attention to unequal enforcement.
@@ -73,7 +77,7 @@ His deeper achievement was to change the burden of proof. The question was no lo
 
 None of these objections erases his contribution. They remind us that replacing cruelty requires more than changing the sentence; it requires examining the entire institution that produces it.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - Pietro Verri’s writings on torture.
 - The Leopoldine Code and Tuscany’s abolition of capital punishment.
@@ -81,7 +85,7 @@ None of these objections erases his contribution. They remind us that replacing 
 - Whether severity, certainty, or social conditions matter most in deterrence.
 - The presumption of innocence and the history of evidentiary rules.
 
-## Sources and Further Reading
+## 📚 Sources and Further Reading
 
 - [Cambridge University Press — “Of torture”](https://www.cambridge.org/core/books/abs/beccaria-on-crimes-and-punishments-and-other-writings/of-torture/41ED74477646ED726FEBD0783F7C70EE)
 - [Online Library of Liberty — *An Essay on Crimes and Punishments*](https://oll.libertyfund.org/titles/beccaria-an-essay-on-crimes-and-punishments)

--- a/people/elizabeth-fry.md
+++ b/people/elizabeth-fry.md
@@ -1,12 +1,14 @@
-# Elizabeth Fry
+# 🕯️ Elizabeth Fry
 
-## Why She Matters
+*The Quaker reformer who walked into Newgate Prison, saw the human cost of polite neglect, and started rearranging the moral furniture.*
+
+## ✨ Why She Matters
 
 Elizabeth Fry (1780–1845) walked into Newgate Prison, saw women and children living in appalling conditions, and refused to classify the scene as somebody else’s unfortunate administrative casserole.
 
-Her campaign helped make the daily treatment of prisoners—especially women—an issue that respectable society and Parliament had to confront. Where [Cesare Beccaria](cesare-beccaria.md) attacked cruel law in theory, Fry entered the institution and started moving furniture.
+Her campaign helped make the daily treatment of prisoners—especially women—an issue that respectable society and Parliament had to confront. Where [Cesare Beccaria](cesare-beccaria.md) attacked cruel law in theory, Fry entered the institution and started moving furniture. Actual furniture, moral furniture, bureaucratic furniture: the whole depressing showroom.
 
-## The Interesting Bits
+## 👀 The Interesting Bits
 
 Fry was born Elizabeth Gurney into a wealthy English Quaker family. Her religion stressed conscience, equality before God, and active service. Wealth and connections gave her access to powerful audiences; faith pushed her toward people those audiences preferred not to see.
 
@@ -14,23 +16,23 @@ She first visited Newgate in the 1810s. Women awaiting trial, convicted prisoner
 
 Fry returned with clothing and practical help. In 1817 she helped establish the Association for the Improvement of the Female Prisoners in Newgate, an organised group of women working directly inside a male-governed penal world.
 
-Her method had a practical scientist’s rhythm: observe the actual conditions, reject the convenient explanation, change something concrete, return, and see whether it helped. No grand theory could make a freezing child warmer. Blankets remained stubbornly evidence-based.
+Her method had a practical scientist’s rhythm: observe the actual conditions, reject the convenient explanation, change something concrete, return, and see whether it helped. No grand theory could make a freezing child warmer. Blankets remained stubbornly evidence-based, which is annoying for anyone trying to win an argument with vibes alone.
 
-## Signature Ideas
+## 💡 Signature Ideas
 
-### Prisoners remained human
+### 🧍 Prisoners remained human
 
 This sounds embarrassingly basic. It was also transformative.
 
 Fry’s work treated imprisoned women as people capable of learning, working, worshipping, parenting, and returning to society—not waste material left over after sentencing.
 
-### Conditions affect conduct
+### 🏚️ Conditions affect conduct
 
 She rejected the convenient theory that chaos inside prisons merely revealed prisoners’ defective character. Overcrowding, idleness, exploitation, lack of separation, and absent supervision produced more chaos.
 
 In software terms, officials blamed the users while the production environment was on fire and a goat had administrator access.
 
-### Reform required practical structure
+### 🧰 Reform required practical structure
 
 Fry promoted:
 
@@ -44,7 +46,7 @@ Fry promoted:
 
 These measures combined compassion, discipline, religion, and preparation for release.
 
-## A Complicated Kind of Humanity
+## 🪞 A Complicated Kind of Humanity
 
 Fry’s programme was not modern liberation politics. It encouraged a particular Quaker and middle-class ideal of respectable femininity: sober, industrious, orderly, religious, and domestic.
 
@@ -52,7 +54,7 @@ Education and work could provide agency, but they could also train women to fit 
 
 That tension matters. A reformer can reduce suffering while carrying assumptions we should question. History is rarely divided into villains with spikes and heroes with flawless policy documents.
 
-## What Changed
+## 🌍 What Changed
 
 Fry gave evidence to a House of Commons committee in 1818—an unusual public role for a woman at the time. Her fame helped spread prison visiting and reform organisations in Britain and Europe.
 
@@ -60,7 +62,7 @@ Her campaigning contributed to a climate in which prisons were expected to provi
 
 That is a crucial stage in the [long movement away from spectacular punishment](../concepts/from-pikes-to-prison-reform.md). Once punishment disappeared behind walls, somebody had to insist on looking behind the walls.
 
-## Strange But True
+## 🎩 Strange But True
 
 - Fry and her husband Joseph had eleven children while she maintained an enormous programme of travel, correspondence, visiting, and campaigning. Her calendar presumably emitted smoke.
 - Had she needed a socially acceptable explanation for yet another prison inspection, one suspects a magnificently fictional cousin with a textile concern and urgent parliamentary business would have materialised by luncheon.
@@ -68,7 +70,7 @@ That is a crucial stage in the [long movement away from spectacular punishment](
 - She became an international celebrity and met royalty, yet her central method remained the stubbornly unglamorous prison visit.
 - Her image appeared on the Bank of England £5 note from 2002 to 2017.
 
-## Why She Still Matters
+## 🔦 Why She Still Matters
 
 Fry’s most durable question is not whether a person deserved a sentence. It is:
 
@@ -76,7 +78,7 @@ Fry’s most durable question is not whether a person deserved a sentence. It is
 
 That question applies to prisons, immigration detention, youth justice, psychiatric institutions, police custody, and anywhere else suffering can become invisible through a locked door and a laminated procedure.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - John Howard and early prison inspection.
 - Women and children in Newgate Prison.
@@ -84,7 +86,7 @@ That question applies to prisons, immigration detention, youth justice, psychiat
 - Convict transportation and Fry’s visits to prison ships.
 - Modern abolitionist critiques of “reforming” prisons.
 
-## Sources and Further Reading
+## 📚 Sources and Further Reading
 
 - [London Museum — Elizabeth Fry: pioneering prison reformer](https://www.londonmuseum.org.uk/collections/london-stories/elizabeth-fry/)
 - [National Portrait Gallery — Elizabeth Fry and civic values](https://www.npg.org.uk/assets/files/pdf/learning/Portraiture_Citizenship_2018.pdf)

--- a/people/jeremy-bentham.md
+++ b/people/jeremy-bentham.md
@@ -1,6 +1,8 @@
-# Jeremy Bentham
+# 👁️ Jeremy Bentham
 
-## Why He Matters
+*The philosopher who tried to spreadsheet morality, redesign punishment, and then accidentally invented one of history’s most unsettling surveillance metaphors. Productive fellow. Slightly alarming stationery.*
+
+## ✨ Why He Matters
 
 Jeremy Bentham (1748–1832) tried to make law answer a blunt engineering question: does this institution produce more well-being than suffering?
 
@@ -8,9 +10,9 @@ Applied to punishment, that was dynamite in a waistcoat. If punishment causes pa
 
 Bentham had the intoxicating confidence of a man who believed society’s moral engine could be opened on a workbench, measured, relabelled, and reassembled with two fewer cruelties and a vastly improved spreadsheet. This is admirable right up to the moment he reaches for the surveillance components.
 
-Then Bentham designed the Panopticon, a prison organised around possible constant observation, and the humane reform story acquired ominous synthesiser music.
+Then Bentham designed the Panopticon, a prison organised around possible constant observation, and the humane reform story acquired ominous synthesiser music. The album was called *Now That’s What I Call Institutional Anxiety*.
 
-## The Interesting Bits
+## 🧠 The Interesting Bits
 
 Bentham was an English philosopher, legal reformer, relentless manuscript producer, and central architect of classical utilitarianism. He argued that policy should aim at the greatest happiness and assess actions through their consequences.
 
@@ -18,9 +20,9 @@ He found English common law obscure, inconsistent, and inaccessible. His answer 
 
 He proposed reforms across an astonishing range of subjects, including government, education, poor relief, sexuality, animal treatment, and prisons. UCL’s Bentham Project works through roughly 60,000 manuscript folios. The man apparently regarded “maybe stop writing now” as an unconstitutional proposal.
 
-## Signature Ideas
+## 💡 Signature Ideas
 
-### Punishment starts in moral debt
+### 🧾 Punishment starts in moral debt
 
 Bentham’s baseline was that all punishment is harmful. It therefore needs a consequential justification such as:
 
@@ -33,13 +35,13 @@ Punishment should not occur when it is groundless, ineffective, unprofitable, or
 
 That framework helped move criminal justice away from sacred vengeance and toward explicit policy goals. It also invited a permanent argument about whose happiness counts and who gets handed the calculator.
 
-### Proportionality should be designed
+### 📏 Proportionality should be designed
 
 A penalty needed enough force to outweigh the expected benefit of offending, but excess severity created needless suffering. Bentham tried to make penalties predictable and calibrated rather than arbitrary.
 
 It is criminal law as interface design: make consequences legible, consistent, and no more hostile than the function requires. Regrettably, most interfaces do not include transportation to Australia.
 
-### The Panopticon
+### 👀 The Panopticon
 
 Bentham’s proposed Panopticon placed a watchtower at the centre of a circular institution. People in the surrounding cells could not know when they were being watched, so the possibility of observation was meant to encourage continuous self-discipline.
 
@@ -55,13 +57,13 @@ Bentham therefore embodies a major historical trade:
 
 That is an improvement in some respects and a warning in others. The dungeon changed key, but the bass line continued.
 
-## Strange But True
+## 🎩 Strange But True
 
 Bentham requested that his body be dissected and preserved after death. His dressed skeleton and wax head became UCL’s “Auto-Icon,” now displayed at the university.
 
-This was consistent with his support for medical dissection and his campaign against taboos that prevented bodies from being useful after death. It was also extremely on-brand. Some philosophers leave a school of thought; Bentham additionally left himself in a glass case.
+This was consistent with his support for medical dissection and his campaign against taboos that prevented bodies from being useful after death. It was also extremely on-brand. Some philosophers leave a school of thought; Bentham additionally left himself in a glass case, as if footnotes had finally achieved skeleton form.
 
-## What He Changed
+## 🌍 What He Changed
 
 Bentham helped give reformers a reusable test: punishment is not self-justifying. Officials must explain what good it achieves, whether a less harmful option would work, and whether the penalty matches the offence.
 
@@ -71,7 +73,7 @@ This connects him to:
 - [Elizabeth Fry](elizabeth-fry.md), who confronted what institutional punishment did in daily practice;
 - the wider move [from spectacular punishment to modern criminal justice](../concepts/from-pikes-to-prison-reform.md).
 
-## Contradictions and Limits
+## 🧱 Contradictions and Limits
 
 - A system optimised for aggregate welfare may sacrifice unpopular minorities.
 - Surveillance can produce orderly institutions while crushing privacy and autonomy.
@@ -80,7 +82,7 @@ This connects him to:
 
 His importance lies partly in this ambiguity. Modern punishment is not simply ancient cruelty with the cruelty removed. It carries Bentham’s promise of rational prevention and his nightmare of frictionless observation.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - Michel Foucault’s use of the Panopticon in *Discipline and Punish*.
 - Bentham’s “felicific calculus” and whether well-being can be compared.
@@ -88,7 +90,7 @@ His importance lies partly in this ambiguity. Modern punishment is not simply an
 - His arguments about animal suffering.
 - The difference between external inspection of institutions and internal surveillance of inmates.
 
-## Sources and Further Reading
+## 📚 Sources and Further Reading
 
 - [UCL — About the Bentham Project](https://www.ucl.ac.uk/laws/research/research-projects/bentham-project/about-bentham-project)
 - [UCL Discovery — Bentham’s penal theory and punishment](https://discovery.ucl.ac.uk/id/eprint/10219771)

--- a/people/robert-badinter.md
+++ b/people/robert-badinter.md
@@ -1,18 +1,20 @@
-# Robert Badinter
+# 🕊️ Robert Badinter
 
-## Why He Matters
+*The lawyer and minister who helped France put away the guillotine, not as a museum prop with excellent blade maintenance, but as a legal power the state no longer deserved.*
+
+## ✨ Why He Matters
 
 Robert Badinter (1928–2024) helped end the death penalty in France, the country that had turned decapitation into an Enlightenment-era machine and then kept the machine available into the age of the Space Shuttle.
 
 As a defence lawyer he failed to save a client from the guillotine. As minister of justice he stood before Parliament in 1981 and asked the French state to give up the power to execute. This time, he won.
 
-## The Interesting Bits
+## 👀 The Interesting Bits
 
 Badinter was born in Paris to a Jewish family. During the Nazi occupation and Vichy regime, his father Simon was arrested, deported, and murdered at Sobibór. Robert survived in hiding.
 
-He studied literature and law, spent time at Columbia University in New York, and joined the Paris bar in 1951. His later opposition to state killing cannot be reduced to one biographical cause, but he knew personally what happens when law, bureaucracy, and dehumanisation join the same band.
+He studied literature and law, spent time at Columbia University in New York, and joined the Paris bar in 1951. His later opposition to state killing cannot be reduced to one biographical cause, but he knew personally what happens when law, bureaucracy, and dehumanisation join the same band. Historically, that band has never produced a decent chorus.
 
-## The Case That Changed His Life
+## ⚡ The Case That Changed His Life
 
 In 1972 Badinter defended Roger Bontems, who had participated in a prison hostage-taking with Claude Buffet. Although Bontems had not personally committed the killings, both men were sentenced to death and guillotined.
 
@@ -24,7 +26,7 @@ Badinter went on to save several other defendants from execution. He did not mak
 
 His problem had the shape of an impossible rescue calculation: protect society, honour victims, respect public fear, and still remove the irreversible act. The answer was not to pretend one variable did not exist. It was to show that a justice system confident enough to punish could also be disciplined enough not to kill.
 
-## The 1981 Abolition
+## 🗳️ The 1981 Abolition
 
 President François Mitterrand appointed Badinter minister of justice in 1981. On 17 September he addressed the National Assembly on the government’s abolition bill.
 
@@ -32,17 +34,17 @@ The debate occurred while a majority of surveyed French citizens still supported
 
 Badinter later worked to anchor abolition through European human-rights commitments. He also pursued prison and justice reforms, including alternatives to detention and improved medical care and preparation for release.
 
-## Signature Ideas
+## 💡 Signature Ideas
 
-### Justice must not imitate murder
+### 🛑 Justice must not imitate murder
 
 Badinter’s case was moral and institutional: a democracy should not answer killing with a planned, bureaucratically organised killing of its own.
 
-### Irreversibility changes everything
+### 🔒 Irreversibility changes everything
 
 Courts can make mistakes. A prison sentence can at least be halted or corrected. An execution converts error into architecture.
 
-### Public opinion is not the ceiling of rights
+### 🧭 Public opinion is not the ceiling of rights
 
 Badinter’s victory raises an enduring democratic question: should legislators follow majority opinion when a fundamental right is at stake, or lead it?
 
@@ -50,11 +52,11 @@ He and the abolitionist majority chose leadership. Democracy, in this view, is n
 
 Nor can a state defend execution with the institutional equivalent of an improvised fake uncle: “the guillotine is regrettable, certainly, but it is also a decorated deterrence consultant who once saved Easter.” If the penalty is irreversible, the justification must survive evidence, error, and principle—not merely arrive wearing a lanyard.
 
-### The condemned person is more than the crime
+### 🧍 The condemned person is more than the crime
 
 Badinter defended people accused of horrific acts without pretending the acts were minor or the victims irrelevant. His argument was that human dignity and restraint mean little if reserved for sympathetic cases.
 
-## From Spectacle to Storage
+## 🚪 From Spectacle to Storage
 
 France’s last public execution occurred in 1939. Its final execution took place in 1977, out of public view. Badinter’s achievement in 1981 removed the guillotine from law rather than merely moving it behind a prison wall.
 
@@ -66,7 +68,7 @@ This completes one arc in the broader story [from public bodily punishment to hu
 
 The sequence was neither inevitable nor permanent by natural law. It required people willing to defend an unpopular boundary.
 
-## Contradictions and Limits
+## 🧱 Contradictions and Limits
 
 Abolishing execution did not make French prisons humane or the justice system equal. Badinter himself acknowledged the need for broader penal reform.
 
@@ -74,7 +76,7 @@ The state can degrade people without killing them. Overcrowding, isolation, inde
 
 Badinter removed one irreversible cruelty. The rest of the work did not politely evaporate in a puff of republican smoke.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - The trials of Roger Bontems and Patrick Henry.
 - Badinter’s 17 September 1981 abolition speech.
@@ -83,7 +85,7 @@ Badinter removed one irreversible cruelty. The rest of the work did not politely
 - Protocols 6 and 13 to the European Convention on Human Rights.
 - Why abolition sometimes precedes a change in majority opinion.
 
-## Sources and Further Reading
+## 📚 Sources and Further Reading
 
 - [Élysée — Robert Badinter biography and abolition campaign](https://www.elysee.fr/emmanuel-macron/2024/02/09/disparition-de-robert-badinter)
 - [Vie publique — the road to abolition](https://www.vie-publique.fr/files/2023-03/9782111577312-extrait.pdf)

--- a/people/vlad-iii-dracula.md
+++ b/people/vlad-iii-dracula.md
@@ -1,22 +1,24 @@
-# Vlad III Dracula
+# 🩸 Vlad III Dracula
 
-## Why He Matters
+*The Wallachian ruler behind the Impaler legend: part frontier prince, part propaganda bonfire, part historical warning label with very sharp edges.*
+
+## ✨ Why He Matters
 
 Vlad III, prince of Wallachia (born around 1431 and dead by early 1477), is remembered as Vlad the Impaler. His rule shows how spectacular cruelty could function as policy: punishment, political centralisation, battlefield psychology, and personal branding from the deepest circle of hell.
 
 He is also a warning about sources. The historical ruler was brutal. The familiar mega-villain was assembled from fact, hostile propaganda, heroic counter-traditions, and a later fictional vampire who borrowed his name but not his complete résumé.
 
-His reputation is therefore two investigations wearing one cloak: what Vlad did, and what generations of frightened, hostile, admiring, or commercially alert people needed “Vlad” to mean. Pull those threads apart and the story becomes more interesting, not less—although the cloak remains extremely banned from the laboratory.
+His reputation is therefore two investigations wearing one cloak: what Vlad did, and what generations of frightened, hostile, admiring, or commercially alert people needed “Vlad” to mean. Pull those threads apart and the story becomes more interesting, not less—although the cloak remains extremely banned from the laboratory and has absolutely failed its workplace safety inspection.
 
-## The World Around Him
+## 🗺️ The World Around Him
 
-Wallachia sat between powerful neighbours, particularly the expanding Ottoman Empire and the Kingdom of Hungary. Its throne was less a comfortable chair than a medieval ejector seat. Rival noble factions, foreign powers, tribute, hostage-taking, and repeated changes of ruler were normal political weather.
+Wallachia sat between powerful neighbours, particularly the expanding Ottoman Empire and the Kingdom of Hungary. Its throne was less a comfortable chair than a medieval ejector seat. Rival noble factions, foreign powers, tribute, hostage-taking, and repeated changes of ruler were normal political weather. Bring an umbrella. Also maybe armour.
 
 Vlad was a son of Vlad II Dracul. “Dracul” referred to his father’s association with the Order of the Dragon; “Dracula” or *Drăculea* meant son of Dracul. Bram Stoker later used Dracula for his fictional count, helping weld two very different figures together in popular memory.
 
 Vlad ruled Wallachia on three occasions. His longest reign, from 1456 to 1462, included conflict with the Ottoman sultan Mehmed II and violent efforts to control internal rivals.
 
-## The Terrible Acts
+## ⚔️ The Terrible Acts
 
 Vlad became notorious for impalement: placing victims on stakes and leaving their bodies visible. It was prolonged killing and public display combined, a punishment engineered to terrify witnesses as much as destroy victims.
 
@@ -29,7 +31,7 @@ He used violence against several categories of people described in surviving acc
 
 The most famous story describes Mehmed II encountering a “forest” of impaled bodies outside Târgoviște in 1462. The tableau’s precise scale is uncertain, but its logic is plain: bodies became fortifications for the imagination.
 
-## Propaganda With a Printing Press
+## 📰 Propaganda With a Printing Press
 
 German-language pamphlets portrayed Vlad as a monstrous tyrant and circulated lurid stories of mass killing. Some originated in communities hostile to him; the new medium of print gave these accounts impressive touring legs.
 
@@ -45,7 +47,7 @@ Both portraits have agendas. Even modern estimates of his victims vary enormousl
 
 History frequently hands us a smoke machine and asks for a census.
 
-## Signature Idea: Terror as Infrastructure
+## 🏗️ Signature Idea: Terror as Infrastructure
 
 Vlad’s violence was not merely an uncontrolled temper. It communicated rules, punished defiance, intimidated armies, and helped a precarious ruler compensate for limited resources.
 
@@ -53,14 +55,14 @@ That is what makes him relevant to the broader [history of punishment](../concep
 
 Explanation is not exoneration. “Strategic” cruelty remains cruelty; giving the nightmare a flowchart does not make it less of a nightmare.
 
-## Strange But True
+## 🎩 Strange But True
 
 - Dracula the vampire is not a biography of Vlad. Stoker appears to have borrowed the name and fragments of historical atmosphere.
-- Vlad can be remembered as a national defender and an atrocity figure at the same time. Collective memory contains merge conflicts.
+- Vlad can be remembered as a national defender and an atrocity figure at the same time. Collective memory contains merge conflicts, and nobody has written the migration script.
 - His nickname in Romanian, *Țepeș* (“the Impaler”), became common after his lifetime.
 - The most extravagant stories tell us as much about early print culture and political enemies as they do about Vlad.
 
-## Why He Belongs in This Collection
+## 🧭 Why He Belongs in This Collection
 
 Vlad represents the far end of exemplary punishment: suffering made visible so that fear could govern people who were still alive.
 
@@ -71,7 +73,7 @@ The reformers in this collection attacked different joints in that machinery:
 - [Elizabeth Fry](elizabeth-fry.md) insisted that prisoners remained people.
 - [Robert Badinter](robert-badinter.md) helped remove the guillotine from French law.
 
-## Follow-Up Rabbit Holes
+## 🕳️ Follow-Up Rabbit Holes
 
 - Mehmed II and the 1462 campaign in Wallachia.
 - How Ottoman, Slavic, German, and Romanian sources construct different Vlads.
@@ -79,7 +81,7 @@ The reformers in this collection attacked different joints in that machinery:
 - The difference between terror as battlefield strategy and terror as domestic government.
 - How Bram Stoker found and transformed the name “Dracula.”
 
-## Sources and Further Reading
+## 📚 Sources and Further Reading
 
 - [UCL Discovery — discussion of contemporary imagery and impalement in Vlad’s region](https://discovery.ucl.ac.uk/1322691/1/1322691_Volume_1.pdf)
 - [Live Science — overview with discussion of recent scholarship and inflated figures](https://www.livescience.com/40843-real-dracula-vlad-the-impaler.html)


### PR DESCRIPTION
## Summary
- refresh Adobe, From Pikes to Prison Reform, and five related biography notes with the updated Curiosity Cabinet writing style
- add emoji signposts to titles, section headings, callouts, and source/rabbit-hole sections
- add a few livelier intros and memorable explanatory lines while preserving the existing facts and source shelves

## Testing
- ran git diff --check
- no automated tests; Markdown content only